### PR TITLE
Register Parquet batches atomically

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,9 @@
 
 * New `add_data_files()` registers existing Parquet files with a table
   without copying or rewriting them -- the migration path for data that is
-  already in Parquet. `list_ducklake_files()` shows the files backing a
+  already in Parquet. A vector of files is registered atomically in one
+  snapshot, and `create = TRUE` can bootstrap a new target table directly
+  from the Parquet schema. `list_ducklake_files()` shows the files backing a
   table, optionally as of a past snapshot.
 
 * New sorted-table support: `set_table_sorting()` and

--- a/R/data_files.R
+++ b/R/data_files.R
@@ -3,11 +3,11 @@
 #' Adds Parquet files that already exist on disk (or object storage) to a
 #' DuckLake table without copying or rewriting them. This is the migration
 #' path for data that is already in Parquet: the files are recorded in the
-#' catalog in place, and one snapshot is created per file added.
+#' catalog in place.
 #'
-#' @param table_name The table to add the files to. It must already exist
-#'   with a schema compatible with the files (see `allow_missing` and
-#'   `ignore_extra_columns` for the two permitted mismatches).
+#' @param table_name The table to add the files to. Unless `create = TRUE`, it
+#'   must already exist with a schema compatible with the files (see
+#'   `allow_missing` and `ignore_extra_columns` for the permitted mismatches).
 #' @param files Character vector of Parquet file paths or URIs.
 #' @param schema_name Optional schema containing the table (defaults to the
 #'   lake's `main` schema).
@@ -19,10 +19,20 @@
 #'   `FALSE`.
 #' @param ducklake_name Optional name of the attached DuckLake catalog. If
 #'   `NULL`, the current database is used.
+#' @param create If `TRUE`, create an empty target table from the registered
+#'   Parquet schema. The table must not already exist. Default `FALSE`.
 #'
 #' @details
-#' Runs `CALL ducklake_add_data_files(...)` once per file. Ownership of each
-#' file transfers to DuckLake: compaction (e.g.
+#' Runs `CALL ducklake_add_data_files(...)` once per file. The complete vector
+#' is atomic: outside an existing transaction the function opens one, so the
+#' batch creates one snapshot and any failure rolls back every registration.
+#' Inside [with_transaction()] the registrations join the caller's snapshot.
+#'
+#' With `create = TRUE`, the table schema is read from the complete file list
+#' with `read_parquet()` and created with zero rows before registration. Neither
+#' this path nor registration copies the data or materializes it in R.
+#'
+#' Ownership of each file transfers to DuckLake: compaction (e.g.
 #' [merge_adjacent_files()]) may later rewrite and delete it, so do not add
 #' files that something else still relies on.
 #'
@@ -44,18 +54,29 @@
 #'   c("extracts/jan.parquet", "extracts/feb.parquet"),
 #'   ignore_extra_columns = TRUE
 #' )
+#'
+#' # Create a new table and register an existing Parquet batch atomically
+#' add_data_files(
+#'   "clinvar_staging",
+#'   "extracts/clinvar-2026-07.parquet",
+#'   create = TRUE
+#' )
 #' }
 add_data_files <- function(table_name,
                            files,
                            schema_name = NULL,
                            allow_missing = FALSE,
                            ignore_extra_columns = FALSE,
-                           ducklake_name = NULL) {
+                           ducklake_name = NULL,
+                           create = FALSE) {
   conn <- get_ducklake_connection()
   ducklake_name <- infer_ducklake_name(ducklake_name, conn)
 
   if (!is.character(files) || length(files) == 0 || anyNA(files)) {
     cli::cli_abort("{.arg files} must be a character vector of file paths.")
+  }
+  if (!is.logical(create) || length(create) != 1 || is.na(create)) {
+    cli::cli_abort("{.arg create} must be `TRUE` or `FALSE`.")
   }
 
   extra <- paste0(
@@ -67,6 +88,37 @@ add_data_files <- function(table_name,
     if (allow_missing) ", allow_missing => true" else "",
     if (ignore_extra_columns) ", ignore_extra_columns => true" else ""
   )
+
+  own_txn <- !in_transaction(conn)
+  committed <- FALSE
+  if (own_txn) {
+    DBI::dbExecute(conn, "BEGIN TRANSACTION;")
+    on.exit(
+      if (!committed) {
+        tryCatch(DBI::dbExecute(conn, "ROLLBACK;"), error = function(e) NULL)
+      },
+      add = TRUE
+    )
+  }
+
+  if (create) {
+    target_schema <- if (is.null(schema_name)) "main" else schema_name
+    target <- quote_ident(
+      paste(ducklake_name, target_schema, table_name, sep = "."),
+      conn
+    )
+    file_list <- paste(
+      vapply(files, quote_sql, character(1)),
+      collapse = ", "
+    )
+    db_execute(
+      sprintf(
+        "CREATE TABLE %s AS SELECT * FROM read_parquet([%s]) LIMIT 0;",
+        target, file_list
+      ),
+      conn = conn
+    )
+  }
 
   for (file in files) {
     db_execute(
@@ -81,8 +133,14 @@ add_data_files <- function(table_name,
     )
   }
 
+  if (own_txn) {
+    DBI::dbExecute(conn, "COMMIT;")
+    committed <- TRUE
+  }
+
   cli::cli_inform(c(
     "Added {length(files)} file{?s} to table {.val {table_name}}.",
+    "i" = "The batch was registered atomically in one DuckLake snapshot.",
     "i" = "DuckLake now owns the added file{cli::qty(length(files))}{?s}; compaction may rewrite or delete {?it/them}."
   ))
 

--- a/man/add_data_files.Rd
+++ b/man/add_data_files.Rd
@@ -10,13 +10,14 @@ add_data_files(
   schema_name = NULL,
   allow_missing = FALSE,
   ignore_extra_columns = FALSE,
-  ducklake_name = NULL
+  ducklake_name = NULL,
+  create = FALSE
 )
 }
 \arguments{
-\item{table_name}{The table to add the files to. It must already exist
-with a schema compatible with the files (see \code{allow_missing} and
-\code{ignore_extra_columns} for the two permitted mismatches).}
+\item{table_name}{The table to add the files to. Unless \code{create = TRUE}, it
+must already exist with a schema compatible with the files (see
+\code{allow_missing} and \code{ignore_extra_columns} for the permitted mismatches).}
 
 \item{files}{Character vector of Parquet file paths or URIs.}
 
@@ -33,6 +34,9 @@ table does not have; the extra columns are inaccessible. Default
 
 \item{ducklake_name}{Optional name of the attached DuckLake catalog. If
 \code{NULL}, the current database is used.}
+
+\item{create}{If \code{TRUE}, create an empty target table from the registered
+Parquet schema. The table must not already exist. Default \code{FALSE}.}
 }
 \value{
 Invisibly returns the character vector of files added.
@@ -41,11 +45,19 @@ Invisibly returns the character vector of files added.
 Adds Parquet files that already exist on disk (or object storage) to a
 DuckLake table without copying or rewriting them. This is the migration
 path for data that is already in Parquet: the files are recorded in the
-catalog in place, and one snapshot is created per file added.
+catalog in place.
 }
 \details{
-Runs \verb{CALL ducklake_add_data_files(...)} once per file. Ownership of each
-file transfers to DuckLake: compaction (e.g.
+Runs \verb{CALL ducklake_add_data_files(...)} once per file. The complete vector
+is atomic: outside an existing transaction the function opens one, so the
+batch creates one snapshot and any failure rolls back every registration.
+Inside \code{\link[=with_transaction]{with_transaction()}} the registrations join the caller's snapshot.
+
+With \code{create = TRUE}, the table schema is read from the complete file list
+with \code{read_parquet()} and created with zero rows before registration. Neither
+this path nor registration copies the data or materializes it in R.
+
+Ownership of each file transfers to DuckLake: compaction (e.g.
 \code{\link[=merge_adjacent_files]{merge_adjacent_files()}}) may later rewrite and delete it, so do not add
 files that something else still relies on.
 }
@@ -60,6 +72,13 @@ add_data_files(
   "readings",
   c("extracts/jan.parquet", "extracts/feb.parquet"),
   ignore_extra_columns = TRUE
+)
+
+# Create a new table and register an existing Parquet batch atomically
+add_data_files(
+  "clinvar_staging",
+  "extracts/clinvar-2026-07.parquet",
+  create = TRUE
 )
 }
 }

--- a/tests/testthat/test-data-files.R
+++ b/tests/testthat/test-data-files.R
@@ -19,7 +19,10 @@ test_that("add_data_files registers an existing parquet file without copying", {
     )
   )
 
-  suppressMessages(add_data_files("adf_target", external_file))
+  # Preserve the pre-existing positional signature through ducklake_name.
+  suppressMessages(add_data_files(
+    "adf_target", external_file, NULL, FALSE, FALSE, lake$ducklake_name
+  ))
 
   result <- dplyr::collect(get_ducklake_table("adf_target"))
   expect_equal(nrow(result), 4)
@@ -28,6 +31,104 @@ test_that("add_data_files registers an existing parquet file without copying", {
   files_after <- list_ducklake_files("adf_target")
   expect_equal(nrow(files_after), nrow(files_before) + 1)
   expect_true(any(grepl("external.parquet", files_after$data_file, fixed = TRUE)))
+
+  cleanup_temp_ducklake(lake)
+})
+
+test_that("add_data_files registers a batch in one snapshot", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  create_table(data.frame(id = 1L), "adf_batch")
+  snapshots_before <- list_table_snapshots("adf_batch")
+
+  external_files <- file.path(
+    lake$temp_dir, c("batch-2.parquet", "batch-3.parquet")
+  )
+  for (i in seq_along(external_files)) {
+    DBI::dbExecute(
+      lake$conn,
+      sprintf(
+        "COPY (SELECT %d AS id) TO %s (FORMAT parquet);",
+        i + 1L, quote_sql(external_files[[i]])
+      )
+    )
+  }
+
+  suppressMessages(add_data_files("adf_batch", external_files))
+
+  result <- dplyr::collect(get_ducklake_table("adf_batch"))
+  snapshots_after <- list_table_snapshots("adf_batch")
+  expect_setequal(result$id, 1:3)
+  expect_equal(nrow(snapshots_after), nrow(snapshots_before) + 1L)
+
+  cleanup_temp_ducklake(lake)
+})
+
+test_that("add_data_files rolls back the complete batch on failure", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  create_table(data.frame(id = 1L), "adf_atomic")
+  files_before <- list_ducklake_files("adf_atomic")
+
+  matching <- file.path(lake$temp_dir, "matching.parquet")
+  incompatible <- file.path(lake$temp_dir, "incompatible.parquet")
+  DBI::dbExecute(
+    lake$conn,
+    sprintf(
+      "COPY (SELECT 2 AS id) TO %s (FORMAT parquet);",
+      quote_sql(matching)
+    )
+  )
+  DBI::dbExecute(
+    lake$conn,
+    sprintf(
+      "COPY (SELECT 'wrong type' AS id) TO %s (FORMAT parquet);",
+      quote_sql(incompatible)
+    )
+  )
+
+  expect_error(
+    suppressMessages(add_data_files("adf_atomic", c(matching, incompatible)))
+  )
+
+  result <- dplyr::collect(get_ducklake_table("adf_atomic"))
+  files_after <- list_ducklake_files("adf_atomic")
+  expect_equal(result$id, 1L)
+  expect_equal(nrow(files_after), nrow(files_before))
+
+  cleanup_temp_ducklake(lake)
+})
+
+test_that("add_data_files can create a table from nested Parquet", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  external_file <- file.path(lake$temp_dir, "nested.parquet")
+  DBI::dbExecute(
+    lake$conn,
+    sprintf(
+      paste(
+        "COPY (SELECT 'record-1' AS record_key,",
+        "[struct_pack(accession := 'SCV1', version := 1)] AS receipts)",
+        "TO %s (FORMAT parquet);"
+      ),
+      quote_sql(external_file)
+    )
+  )
+
+  suppressMessages(
+    add_data_files("registered_nested", external_file, create = TRUE)
+  )
+
+  result <- dplyr::collect(get_ducklake_table("registered_nested"))
+  snapshots <- list_table_snapshots("registered_nested")
+  expect_equal(result$record_key, "record-1")
+  expect_equal(nrow(snapshots), 1L)
 
   cleanup_temp_ducklake(lake)
 })
@@ -63,6 +164,7 @@ test_that("add_data_files and list_ducklake_files validate their inputs", {
     add_data_files("t", character(0)),
     "character vector of file paths"
   )
+  expect_error(add_data_files("t", "file.parquet", create = NA), "create")
   expect_error(
     list_ducklake_files(
       "t",

--- a/vignettes/ducklake.Rmd
+++ b/vignettes/ducklake.Rmd
@@ -142,15 +142,19 @@ with_transaction(
 ### Register existing Parquet files without copying
 
 If your data is already in Parquet, `add_data_files()` records the files in
-the lake in place -- no copy, no rewrite. This is the fast migration path
-from a folder of Parquet extracts. Note that the lake takes ownership of
-the files: later compaction may rewrite or delete them.
+the lake in place -- no copy, no rewrite, and no collection into R. A vector
+of files is registered atomically in one snapshot. This is the fast migration
+path from a folder of Parquet extracts. The target table can already exist
+with a compatible schema, or `create = TRUE` can create it directly from the
+Parquet schema. Note that the lake takes ownership of the files: later
+compaction may rewrite or delete them.
 
 ```{r add_data_files, eval=FALSE}
-# The table must exist with a compatible schema
-create_table(data.frame(id = integer(), value = numeric()), "readings")
-
-add_data_files("readings", c("extracts/jan.parquet", "extracts/feb.parquet"))
+add_data_files(
+  "readings",
+  c("extracts/jan.parquet", "extracts/feb.parquet"),
+  create = TRUE
+)
 
 # See which files back a table
 list_ducklake_files("readings")


### PR DESCRIPTION
Closes #35.

## Why

Our ingestion path starts from many existing Parquet files, including nested `LIST`/`STRUCT` columns. Rewriting those files or collecting them through R duplicates I/O and storage, while manually recreating the nested schema is fragile.

`add_data_files()` already accepts a vector, but currently autocommits each file separately. That produces one snapshot per file and leaves a partially registered batch if a later file is incompatible.

## What changed

- Wrap the complete file vector in one transaction when the caller has not already opened one. A successful batch creates one snapshot; any failed registration rolls back the whole batch.
- Join an existing `with_transaction()` transaction rather than taking over its commit/rollback decision.
- Add `create = TRUE` to create a zero-row target table from the Parquet schema and register the files in the same transaction. The data is neither copied nor materialized in R.
- Append `create` **after** the existing `ducklake_name` formal. This preserves positional compatibility with the released signature; the regression test calls `ducklake_name` as the existing sixth argument.
- Document the atomicity, ownership semantics, and new-table workflow.

The default remains `create = FALSE`, so named and positional calls against an existing table retain their current behavior.

## Verification

- Focused data-file tests: 15 passed.
- Complete testthat suite: 513 passed, 0 failed (one pre-existing dbplyr `na.rm` warning in `test-hardening.R`).
- `R CMD check --no-manual`: **Status: OK** with `_R_CHECK_FORCE_SUGGESTS_=false` because `admiral`, `DiagrammeR`, and `pharmaversesdtm` are unavailable locally.
