### PR TITLE
Keep ducklake_name as add_data_files()'s trailing argument

### DIFF
--- a/R/data_files.R
+++ b/R/data_files.R
@@ -17,10 +17,10 @@
 #' @param ignore_extra_columns If `TRUE`, files may contain columns that the
 #'   table does not have; the extra columns are inaccessible. Default
 #'   `FALSE`.
-#' @param ducklake_name Optional name of the attached DuckLake catalog. If
-#'   `NULL`, the current database is used.
 #' @param create If `TRUE`, create an empty target table from the registered
 #'   Parquet schema. The table must not already exist. Default `FALSE`.
+#' @param ducklake_name Optional name of the attached DuckLake catalog. If
+#'   `NULL`, the current database is used.
 #'
 #' @details
 #' Runs `CALL ducklake_add_data_files(...)` once per file. The complete vector
@@ -67,8 +67,8 @@ add_data_files <- function(table_name,
                            schema_name = NULL,
                            allow_missing = FALSE,
                            ignore_extra_columns = FALSE,
-                           ducklake_name = NULL,
-                           create = FALSE) {
+                           create = FALSE,
+                           ducklake_name = NULL) {
   conn <- get_ducklake_connection()
   ducklake_name <- infer_ducklake_name(ducklake_name, conn)
 
@@ -140,7 +140,11 @@ add_data_files <- function(table_name,
 
   cli::cli_inform(c(
     "Added {length(files)} file{?s} to table {.val {table_name}}.",
-    "i" = "The batch was registered atomically in one DuckLake snapshot.",
+    # Inside a caller's transaction the snapshot is theirs and not yet
+    # committed, so only claim atomicity for a batch this call committed.
+    if (own_txn && length(files) > 1) {
+      c("i" = "The batch was registered atomically in one DuckLake snapshot.")
+    },
     "i" = "DuckLake now owns the added file{cli::qty(length(files))}{?s}; compaction may rewrite or delete {?it/them}."
   ))
 

--- a/man/add_data_files.Rd
+++ b/man/add_data_files.Rd
@@ -10,8 +10,8 @@ add_data_files(
   schema_name = NULL,
   allow_missing = FALSE,
   ignore_extra_columns = FALSE,
-  ducklake_name = NULL,
-  create = FALSE
+  create = FALSE,
+  ducklake_name = NULL
 )
 }
 \arguments{
@@ -32,11 +32,11 @@ table; missing columns read as the column's initial default. Default
 table does not have; the extra columns are inaccessible. Default
 \code{FALSE}.}
 
-\item{ducklake_name}{Optional name of the attached DuckLake catalog. If
-\code{NULL}, the current database is used.}
-
 \item{create}{If \code{TRUE}, create an empty target table from the registered
 Parquet schema. The table must not already exist. Default \code{FALSE}.}
+
+\item{ducklake_name}{Optional name of the attached DuckLake catalog. If
+\code{NULL}, the current database is used.}
 }
 \value{
 Invisibly returns the character vector of files added.

--- a/tests/testthat/test-data-files.R
+++ b/tests/testthat/test-data-files.R
@@ -19,10 +19,7 @@ test_that("add_data_files registers an existing parquet file without copying", {
     )
   )
 
-  # Preserve the pre-existing positional signature through ducklake_name.
-  suppressMessages(add_data_files(
-    "adf_target", external_file, NULL, FALSE, FALSE, lake$ducklake_name
-  ))
+  suppressMessages(add_data_files("adf_target", external_file))
 
   result <- dplyr::collect(get_ducklake_table("adf_target"))
   expect_equal(nrow(result), 4)


### PR DESCRIPTION
Follow-up to #36, two tweaks from review:

- `create` now sits before `ducklake_name`, keeping the catalog argument last like every other function in the package. Nothing positional depends on the old order since `add_data_files()` hasn't shipped to CRAN.
- The one-snapshot atomicity message only prints when the function opened the transaction itself and registered more than one file. Inside `with_transaction()` nothing has committed yet, so the old message overclaimed.

The first data-files test goes back to its original named-argument call; the positional variant was guarding the other ordering.