### PR TITLE
Correct the probe description in cran-comments

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -6,6 +6,10 @@
 
 * This is a new release, so the "New submission" note is expected.
 
+Checked both with the extension present (all examples, tests, and vignettes
+execute) and with it absent (everything gates itself off and the check is
+still clean), since the latter is what the check farm will see.
+
 ## Test environments
 
 * local macOS (aarch64), R 4.5.2
@@ -20,10 +24,11 @@ with the duckdb R package and is downloaded on first use, so nothing in the
 package may assume it is present.
 
 Everything that needs it is gated on `ducklake_extension_available()`, which
-opens a throwaway in-memory DuckDB connection with
-`autoinstall_known_extensions` turned off and attempts `LOAD ducklake`. The
-probe cannot download anything and cannot write to the extension cache in the
-user's home directory. Tests also call `skip_on_cran()`.
+opens a throwaway in-memory DuckDB connection and asks `duckdb_extensions()`
+whether the extension is already installed, loading it only if so. Reading the
+catalog cannot download anything, and loading an already-installed extension
+does not reach the network, so the probe never writes to the extension cache in
+the user's home directory. Tests also call `skip_on_cran()`.
 
 * Examples use `@examplesIf ducklake_extension_available()` and build their
   lakes under `tempdir()`. On a machine with the extension installed they all

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,6 +5,10 @@
 0 errors | 0 warnings | 1 note
 
 * This is a new release, so the "New submission" note is expected.
+* The same note lists "backends", "inlining", and "lakehouse" as possibly
+  misspelled in DESCRIPTION. All three are spelled as intended: "lakehouse"
+  is the term DuckLake uses for its own format, and the other two are the
+  standard spellings for catalog backends and for inlining small writes.
 
 Checked both with the extension present (all examples, tests, and vignettes
 execute) and with it absent (everything gates itself off and the check is


### PR DESCRIPTION
The probe stopped using `SET autoinstall_known_extensions` during the CI fixes in [#42](https://github.com/tgerke/ducklake-r/pull/42); describe what it actually does now (asks `duckdb_extensions()` whether the extension is installed, loads only if so).

Also records that `R CMD check --as-cran` was run twice, with the extension present and absent, since the check farm sees the latter.

`cran-comments.md` is in `.Rbuildignore`, so this does not change the tarball.