### PR TITLE
Load the aws extension for credential_chain secrets

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^cran-comments\.md$
 ^CLAUDE\.md$
 ^Rplots\.pdf$
+^CRAN-SUBMISSION$

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.6.0
+Date: 2026-08-27 14:26:55 UTC
+SHA: cc00a46a70891d7c31dc9e7ac467ae04cff46a2f

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ducklake
 Title: Interact with 'DuckLake' from R
-Version: 0.6.0
+Version: 0.6.0.9000
 Authors@R: c(
     person("Travis", "Gerke", , "travisgerke@gmail.com", role = c("aut", "cre")),
     person("Stefan", "Linner", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ducklake (development version)
+
 # ducklake 0.6.0
 
 First CRAN release.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # ducklake (development version)
 
+* `create_storage_secret(provider = "credential_chain")` now loads DuckDB's
+  aws extension itself for `"s3"`, `"gcs"`, and `"r2"` secrets, installing
+  it on first use. The provider lives in that extension, and DuckDB's
+  automatic mid-statement install of it could fail, leaving `CREATE SECRET`
+  erroring with "Install it first" (#43).
+
 # ducklake 0.6.0
 
 First CRAN release.

--- a/R/storage_secrets.R
+++ b/R/storage_secrets.R
@@ -13,7 +13,9 @@
 #' @param provider Optional credential provider. The common one is
 #'   `"credential_chain"`, which picks up credentials the way AWS SDKs do
 #'   (environment variables, profiles, instance metadata) so no key needs to
-#'   be passed in code.
+#'   be passed in code. For `"s3"`, `"gcs"`, and `"r2"` secrets this provider
+#'   lives in DuckDB's aws extension, which is loaded (and installed on first
+#'   use) automatically.
 #' @param scope Optional URI prefix (e.g. `"s3://my-bucket"`) limiting which
 #'   paths the secret applies to. Useful when different buckets need
 #'   different credentials.
@@ -27,7 +29,12 @@
 #'
 #' @details
 #' The httpfs extension (or the azure extension for `type = "azure"`) is
-#' loaded automatically.
+#' loaded automatically. With `provider = "credential_chain"`, the aws
+#' extension is loaded too: it supplies that provider for `"s3"`, `"gcs"`,
+#' and `"r2"` secrets, and DuckDB's automatic mid-statement install of it
+#' can fail, so the package loads it up front instead. If you pre-install
+#' extensions (say, when baking a container image), include `aws` alongside
+#' `httpfs`. The azure extension provides its own credential chain.
 #'
 #' Prefer `provider = "credential_chain"` over embedding long-lived keys in
 #' scripts. The secret's values are visible in the session via
@@ -70,6 +77,12 @@ create_storage_secret <- function(type = c("s3", "gcs", "r2", "azure"),
 
   extension <- if (type == "azure") "azure" else "httpfs"
   load_or_install_extension(extension, conn = conn)
+
+  # credential_chain lives in the aws extension for s3/gcs/r2 (azure ships its
+  # own); DuckDB's mid-statement autoload of aws is unreliable, so load it here
+  if (identical(provider, "credential_chain") && type != "azure") {
+    load_or_install_extension("aws", conn = conn)
+  }
 
   params <- list(...)
   if (length(params) > 0 &&

--- a/man/create_storage_secret.Rd
+++ b/man/create_storage_secret.Rd
@@ -25,7 +25,9 @@ Character values are quoted; logicals become \code{true}/\code{false}.}
 \item{provider}{Optional credential provider. The common one is
 \code{"credential_chain"}, which picks up credentials the way AWS SDKs do
 (environment variables, profiles, instance metadata) so no key needs to
-be passed in code.}
+be passed in code. For \code{"s3"}, \code{"gcs"}, and \code{"r2"} secrets this provider
+lives in DuckDB's aws extension, which is loaded (and installed on first
+use) automatically.}
 
 \item{scope}{Optional URI prefix (e.g. \code{"s3://my-bucket"}) limiting which
 paths the secret applies to. Useful when different buckets need
@@ -51,7 +53,12 @@ and friends). Wraps \verb{CREATE SECRET}.
 }
 \details{
 The httpfs extension (or the azure extension for \code{type = "azure"}) is
-loaded automatically.
+loaded automatically. With \code{provider = "credential_chain"}, the aws
+extension is loaded too: it supplies that provider for \code{"s3"}, \code{"gcs"},
+and \code{"r2"} secrets, and DuckDB's automatic mid-statement install of it
+can fail, so the package loads it up front instead. If you pre-install
+extensions (say, when baking a container image), include \code{aws} alongside
+\code{httpfs}. The azure extension provides its own credential chain.
 
 Prefer \code{provider = "credential_chain"} over embedding long-lived keys in
 scripts. The secret's values are visible in the session via

--- a/tests/testthat/test-storage-secrets.R
+++ b/tests/testthat/test-storage-secrets.R
@@ -55,6 +55,33 @@ test_that("create_storage_secret validates its inputs", {
   )
 })
 
+test_that("create_storage_secret loads the aws extension for credential_chain", {
+  loaded <- character()
+  local_mocked_bindings(
+    db_execute = function(sql, ...) invisible(NULL),
+    load_or_install_extension = function(ext, ...) {
+      loaded <<- c(loaded, ext)
+      invisible(NULL)
+    }
+  )
+
+  for (type in c("s3", "gcs", "r2")) {
+    loaded <- character()
+    suppressMessages(create_storage_secret(type, provider = "credential_chain"))
+    expect_equal(loaded, c("httpfs", "aws"))
+  }
+
+  # azure's credential chain comes from the azure extension itself
+  loaded <- character()
+  suppressMessages(create_storage_secret("azure", provider = "credential_chain"))
+  expect_equal(loaded, "azure")
+
+  # explicit keys don't need aws
+  loaded <- character()
+  suppressMessages(create_storage_secret("s3", key_id = "k", secret = "s"))
+  expect_equal(loaded, "httpfs")
+})
+
 test_that("render_secret_value renders logicals, numbers, and strings", {
   expect_equal(render_secret_value(TRUE), "true")
   expect_equal(render_secret_value(443), "443")


### PR DESCRIPTION
`create_storage_secret(provider = "credential_chain")` could fail with "Extension aws.duckdb_extension not found ... Install it first". The credential_chain provider for s3, gcs, and r2 secrets lives in the aws extension, and DuckDB's automatic mid-statement install of it is unreliable.

The fix loads aws through the same LOAD-then-INSTALL path already used for httpfs, gated on `provider == "credential_chain"` and skipping azure (its credential chain ships in the azure extension, which is already loaded). The docs now note that container images with pre-installed extensions should include aws alongside httpfs.

Since main is protected, this PR also carries two housekeeping commits: recording the CRAN submission SHA for 0.6.0 and bumping to the development version 0.6.0.9000.

Fixes #43