### PR TITLE
Let the duckdb backend split catalog location from DATA_PATH

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # ducklake (development version)
 
+* The `"duckdb"` backend now honors `catalog_connection_string` as the path
+  for its catalog file, so a single-writer lake can keep the catalog on
+  local disk while `lake_path` points at object storage. The documentation
+  already promised this argument worked for the duckdb backend; now it does
+  (#44).
+
+* `attach_ducklake()` stops early when the duckdb backend would create its
+  catalog file on object storage, which DuckDB cannot write and which
+  previously surfaced as a confusing IO error. The message points to
+  `catalog_connection_string`, to `read_only = TRUE` (attaching an existing
+  remote catalog stays supported), and to the other backends. httpfs is
+  now loaded up front whenever a remote path is involved instead of relying
+  on DuckDB's mid-statement autoload.
+
+* The `create_storage_secret()` example and the storage vignette attached
+  an S3 lake with the default backend and no catalog path, which would put
+  the catalog file itself on S3. Both now show the split layout, and
+  `backup_ducklake()` finds a catalog that lives outside `lake_path`.
+
 # ducklake 0.6.0
 
 First CRAN release.

--- a/R/attach_ducklake.R
+++ b/R/attach_ducklake.R
@@ -10,17 +10,20 @@
 #' See \url{https://ducklake.select/docs/stable/duckdb/usage/choosing_a_catalog_database}.
 #'
 #' @param ducklake_name Name for the ducklake, used as the database alias in DuckDB
-#' @param lake_path Directory path where the lake lives. For `"duckdb"` this is
-#'   where the catalog file and Parquet data are stored. For other backends this
-#'   sets the Parquet data location (DuckLake's `DATA_PATH`), which may also be
-#'   an object-storage URI such as `"s3://bucket/path"` -- register credentials
-#'   first with [create_storage_secret()]. (The `"duckdb"` backend needs a local
-#'   `lake_path`, since its catalog is a database file.)
+#' @param lake_path Directory where the Parquet data files are stored
+#'   (DuckLake's `DATA_PATH`). May be a local directory or an object-storage
+#'   URI such as `"s3://bucket/path"` -- register credentials first with
+#'   [create_storage_secret()]. For `"duckdb"` the catalog file lives in this
+#'   directory too by default; give `catalog_connection_string` to place it
+#'   elsewhere, which is how a local catalog pairs with remote data.
 #' @param backend Catalog backend: `"duckdb"` (default), `"postgres"`,
 #'   `"sqlite"`, or `"mysql"`.
 #' @param catalog_connection_string Backend-specific connection string:
 #'   \describe{
-#'     \item{`"duckdb"`}{Not required. Defaults to `{ducklake_name}.ducklake`.}
+#'     \item{`"duckdb"`}{Optional path for the catalog database file.
+#'       Defaults to `{lake_path}/{ducklake_name}.ducklake`. Set it to keep
+#'       the catalog on local disk while `lake_path` points at object
+#'       storage.}
 #'     \item{`"postgres"`}{libpq string, e.g. `"dbname=mydb host=localhost"`.}
 #'     \item{`"sqlite"`}{Path to the SQLite file, e.g. `"metadata.sqlite"`.}
 #'     \item{`"mysql"`}{MySQL connection string, e.g. `"db=mydb host=localhost"`.}
@@ -126,6 +129,22 @@
 #'   lake_path = "data_files/"
 #' )
 #'
+#' # DuckDB catalog on local disk, Parquet data on S3
+#' create_storage_secret("s3", provider = "credential_chain")
+#' attach_ducklake(
+#'   "trial_lake",
+#'   lake_path = "s3://my-trial-lake/data",
+#'   catalog_connection_string = "trial_lake.ducklake"
+#' )
+#'
+#' # Read-only attach of a .ducklake catalog straight from object storage
+#' attach_ducklake(
+#'   "trial_lake",
+#'   lake_path = "s3://my-trial-lake/data",
+#'   catalog_connection_string = "s3://my-trial-lake/trial_lake.ducklake",
+#'   read_only = TRUE
+#' )
+#'
 #' # Encrypted Parquet files (keys live in the catalog); needs httpfs
 #' attach_ducklake("secure_lake", lake_path = "path/to/lake", encrypted = TRUE)
 #'
@@ -169,6 +188,25 @@ attach_ducklake <- function(ducklake_name, lake_path,
     }
   }
   
+  # DuckDB cannot create or write a database file on object storage, so a
+  # writable duckdb-backend lake needs its catalog on local disk
+  if (backend == "duckdb" && !read_only) {
+    catalog_path <- if (!is.null(catalog_connection_string)) {
+      catalog_connection_string
+    } else {
+      file.path(lake_path, paste0(ducklake_name, ".ducklake"))
+    }
+    if (is_remote_path(catalog_path)) {
+      cli::cli_abort(c(
+        "DuckDB cannot write its catalog file to object storage.",
+        "x" = "The catalog would live at {.val {catalog_path}}.",
+        "i" = "Pass {.arg catalog_connection_string} with a local path for the catalog file; {.arg lake_path} then only sets where the Parquet data goes.",
+        "i" = "Or attach an existing remote catalog with {.code read_only = TRUE}.",
+        "i" = "Or pick a {.arg backend} whose catalog lives elsewhere, such as {.val sqlite} or {.val postgres}."
+      ))
+    }
+  }
+
   if (backend == "mysql") {
     cli::cli_warn(c(
       "MySQL has known issues as a DuckLake catalog backend.",
@@ -191,8 +229,14 @@ attach_ducklake <- function(ducklake_name, lake_path,
     return(invisible(NULL))
   }
 
-  # Load required extensions (ducklake + backend-specific + crypto)
-  ensure_extensions(backend, encrypted = encrypted)
+  # Load required extensions (ducklake + backend-specific + crypto/remote IO)
+  ensure_extensions(
+    backend,
+    encrypted = encrypted,
+    remote = is_remote_path(lake_path) ||
+      (!is.null(catalog_connection_string) &&
+         is_remote_path(catalog_connection_string))
+  )
 
   # Build and run the ATTACH command
   attach_sql <- build_attach_sql(ducklake_name, lake_path, backend,
@@ -221,7 +265,7 @@ attach_ducklake <- function(ducklake_name, lake_path,
 #' @returns The path with runs of `/` collapsed to one.
 #' @noRd
 normalize_lake_path <- function(lake_path) {
-  if (grepl("^[A-Za-z][A-Za-z0-9+.-]*://", lake_path)) {
+  if (is_remote_path(lake_path)) {
     return(lake_path)
   }
   gsub("/{2,}", "/", lake_path)
@@ -234,19 +278,26 @@ normalize_lake_path <- function(lake_path) {
 #'   encrypted files requires the full crypto module from the httpfs
 #'   extension on platforms where the built-in module is read-only
 #'   (notably Windows).
+#' @param remote Whether the data path or catalog path is a remote URI, in
+#'   which case httpfs handles the IO. Loading it up front beats relying on
+#'   DuckDB's mid-statement autoload, which can fail.
 #' @returns Invisibly, `NULL`. Called for its side effect of loading (and, if
 #'   necessary, installing) the required DuckDB extensions.
 #' @keywords internal
-ensure_extensions <- function(backend, encrypted = FALSE) {
+ensure_extensions <- function(backend, encrypted = FALSE, remote = FALSE) {
   load_or_install_extension("ducklake")
 
-  if (encrypted) {
+  if (encrypted || remote) {
     tryCatch(
       load_or_install_extension("httpfs"),
       error = function(e) {
         cli::cli_warn(c(
           "Could not load the {.pkg httpfs} extension: {e$message}",
-          "i" = "Writing encrypted files may fail where DuckDB's built-in crypto module is read-only (e.g., Windows)."
+          "i" = if (encrypted) {
+            "Writing encrypted files may fail where DuckDB's built-in crypto module is read-only (e.g., Windows)."
+          } else {
+            "Remote paths will only work if DuckDB manages to autoload httpfs itself."
+          }
         ))
       }
     )
@@ -269,7 +320,8 @@ ensure_extensions <- function(backend, encrypted = FALSE) {
 #' @param ducklake_name Name for the ducklake alias
 #' @param lake_path Path for data files
 #' @param backend Catalog backend type
-#' @param catalog_connection_string Backend-specific connection string
+#' @param catalog_connection_string Backend-specific connection string; for
+#'   the duckdb backend, an optional path for the catalog file
 #' @param read_only Whether to attach in read-only mode
 #' @param override_data_path Whether to add OVERRIDE_DATA_PATH TRUE
 #' @param data_inlining_row_limit Optional integer for DATA_INLINING_ROW_LIMIT
@@ -288,7 +340,11 @@ build_attach_sql <- function(ducklake_name, lake_path, backend,
                               snapshot_time = NULL) {
   connection_string <- switch(backend,
     duckdb = {
-      ducklake_path <- file.path(lake_path, paste0(ducklake_name, ".ducklake"))
+      ducklake_path <- if (!is.null(catalog_connection_string)) {
+        catalog_connection_string
+      } else {
+        file.path(lake_path, paste0(ducklake_name, ".ducklake"))
+      }
       sprintf("ducklake:%s", ducklake_path)
     },
     postgres = sprintf("ducklake:postgres:%s", catalog_connection_string),

--- a/R/backup_ducklake.R
+++ b/R/backup_ducklake.R
@@ -62,7 +62,7 @@ backup_ducklake <- function(ducklake_name, lake_path, backup_path) {
   if (!is.character(ducklake_name) || length(ducklake_name) != 1) {
     cli::cli_abort("{.arg ducklake_name} must be a single character string.")
   }
-  if (grepl("^[A-Za-z][A-Za-z0-9+.-]*://", lake_path)) {
+  if (is_remote_path(lake_path)) {
     cli::cli_abort(c(
       "{.fn backup_ducklake} only supports local data paths.",
       "x" = "Got remote {.arg lake_path} {.val {lake_path}}.",
@@ -80,12 +80,16 @@ backup_ducklake <- function(ducklake_name, lake_path, backup_path) {
   backup_dir <- file.path(backup_path, paste0("backup_", timestamp))
   dir.create(backup_dir, recursive = TRUE, showWarnings = FALSE)
 
-  # File-based backends: shut down to release file locks, copy, re-attach
+  # File-based backends: shut down to release file locks, copy, re-attach.
+  # Capture the registry's connection string before detaching (which
+  # unregisters the lake); for duckdb it is set when the catalog lives
+  # outside lake_path, and NULL for the default layout.
   if (backend %in% c("duckdb", "sqlite")) {
-    catalog_file <- if (backend == "duckdb") {
+    stored_catalog <- .ducklake_env$lakes[[ducklake_name]]$catalog_connection_string
+    catalog_file <- if (backend == "duckdb" && is.null(stored_catalog)) {
       file.path(lake_path, paste0(ducklake_name, ".ducklake"))
     } else {
-      .ducklake_env$lakes[[ducklake_name]]$catalog_connection_string
+      stored_catalog
     }
 
     if (!is.null(catalog_file) && file.exists(catalog_file)) {
@@ -96,12 +100,8 @@ backup_ducklake <- function(ducklake_name, lake_path, backup_path) {
         to = file.path(backup_dir, basename(catalog_file))
       )
 
-      if (backend == "duckdb") {
-        attach_ducklake(ducklake_name, lake_path = lake_path, backend = backend)
-      } else {
-        attach_ducklake(ducklake_name, lake_path = lake_path, backend = backend,
-                        catalog_connection_string = catalog_file)
-      }
+      attach_ducklake(ducklake_name, lake_path = lake_path, backend = backend,
+                      catalog_connection_string = stored_catalog)
 
       dest_file <- file.path(backup_dir, basename(catalog_file))
       if (copy_ok && file.size(dest_file) > 0) {

--- a/R/storage_secrets.R
+++ b/R/storage_secrets.R
@@ -56,8 +56,13 @@
 #' # Let the AWS credential chain find credentials
 #' create_storage_secret("s3", provider = "credential_chain")
 #'
-#' # Then attach a lake whose data lives on S3
-#' attach_ducklake("trial_lake", lake_path = "s3://my-trial-lake/data")
+#' # Then attach a lake whose data lives on S3. The catalog file stays on
+#' # local disk; lake_path only sets where the Parquet data goes.
+#' attach_ducklake(
+#'   "trial_lake",
+#'   lake_path = "s3://my-trial-lake/data",
+#'   catalog_connection_string = "trial_lake.ducklake"
+#' )
 #' }
 create_storage_secret <- function(type = c("s3", "gcs", "r2", "azure"),
                                   ...,

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,6 +37,15 @@ load_or_install_extension <- function(ext, conn = get_ducklake_connection()) {
   invisible(NULL)
 }
 
+#' Does a path have a URI scheme (s3://, https://, gs://, ...)?
+#'
+#' @param path A single path string.
+#' @returns `TRUE` for remote URIs, `FALSE` for local paths.
+#' @noRd
+is_remote_path <- function(path) {
+  grepl("^[A-Za-z][A-Za-z0-9+.-]*://", path)
+}
+
 #' Quote a (possibly schema-qualified) identifier for SQL
 #'
 #' Splits `x` on `.` and quotes each part with [DBI::dbQuoteIdentifier()],

--- a/man/attach_ducklake.Rd
+++ b/man/attach_ducklake.Rd
@@ -20,19 +20,22 @@ attach_ducklake(
 \arguments{
 \item{ducklake_name}{Name for the ducklake, used as the database alias in DuckDB}
 
-\item{lake_path}{Directory path where the lake lives. For \code{"duckdb"} this is
-where the catalog file and Parquet data are stored. For other backends this
-sets the Parquet data location (DuckLake's \code{DATA_PATH}), which may also be
-an object-storage URI such as \code{"s3://bucket/path"} -- register credentials
-first with \code{\link[=create_storage_secret]{create_storage_secret()}}. (The \code{"duckdb"} backend needs a local
-\code{lake_path}, since its catalog is a database file.)}
+\item{lake_path}{Directory where the Parquet data files are stored
+(DuckLake's \code{DATA_PATH}). May be a local directory or an object-storage
+URI such as \code{"s3://bucket/path"} -- register credentials first with
+\code{\link[=create_storage_secret]{create_storage_secret()}}. For \code{"duckdb"} the catalog file lives in this
+directory too by default; give \code{catalog_connection_string} to place it
+elsewhere, which is how a local catalog pairs with remote data.}
 
 \item{backend}{Catalog backend: \code{"duckdb"} (default), \code{"postgres"},
 \code{"sqlite"}, or \code{"mysql"}.}
 
 \item{catalog_connection_string}{Backend-specific connection string:
 \describe{
-\item{\code{"duckdb"}}{Not required. Defaults to \verb{\{ducklake_name\}.ducklake}.}
+\item{\code{"duckdb"}}{Optional path for the catalog database file.
+Defaults to \verb{\{lake_path\}/\{ducklake_name\}.ducklake}. Set it to keep
+the catalog on local disk while \code{lake_path} points at object
+storage.}
 \item{\code{"postgres"}}{libpq string, e.g. \code{"dbname=mydb host=localhost"}.}
 \item{\code{"sqlite"}}{Path to the SQLite file, e.g. \code{"metadata.sqlite"}.}
 \item{\code{"mysql"}}{MySQL connection string, e.g. \code{"db=mydb host=localhost"}.}
@@ -150,6 +153,22 @@ attach_ducklake(
   backend = "mysql",
   catalog_connection_string = "db=ducklake_catalog host=localhost",
   lake_path = "data_files/"
+)
+
+# DuckDB catalog on local disk, Parquet data on S3
+create_storage_secret("s3", provider = "credential_chain")
+attach_ducklake(
+  "trial_lake",
+  lake_path = "s3://my-trial-lake/data",
+  catalog_connection_string = "trial_lake.ducklake"
+)
+
+# Read-only attach of a .ducklake catalog straight from object storage
+attach_ducklake(
+  "trial_lake",
+  lake_path = "s3://my-trial-lake/data",
+  catalog_connection_string = "s3://my-trial-lake/trial_lake.ducklake",
+  read_only = TRUE
 )
 
 # Encrypted Parquet files (keys live in the catalog); needs httpfs

--- a/man/build_attach_sql.Rd
+++ b/man/build_attach_sql.Rd
@@ -24,7 +24,8 @@ build_attach_sql(
 
 \item{backend}{Catalog backend type}
 
-\item{catalog_connection_string}{Backend-specific connection string}
+\item{catalog_connection_string}{Backend-specific connection string; for
+the duckdb backend, an optional path for the catalog file}
 
 \item{read_only}{Whether to attach in read-only mode}
 

--- a/man/create_storage_secret.Rd
+++ b/man/create_storage_secret.Rd
@@ -73,8 +73,13 @@ create_storage_secret(
 # Let the AWS credential chain find credentials
 create_storage_secret("s3", provider = "credential_chain")
 
-# Then attach a lake whose data lives on S3
-attach_ducklake("trial_lake", lake_path = "s3://my-trial-lake/data")
+# Then attach a lake whose data lives on S3. The catalog file stays on
+# local disk; lake_path only sets where the Parquet data goes.
+attach_ducklake(
+  "trial_lake",
+  lake_path = "s3://my-trial-lake/data",
+  catalog_connection_string = "trial_lake.ducklake"
+)
 }
 }
 \seealso{

--- a/man/ensure_extensions.Rd
+++ b/man/ensure_extensions.Rd
@@ -4,7 +4,7 @@
 \alias{ensure_extensions}
 \title{Install and load required DuckDB extensions for a given backend}
 \usage{
-ensure_extensions(backend, encrypted = FALSE)
+ensure_extensions(backend, encrypted = FALSE, remote = FALSE)
 }
 \arguments{
 \item{backend}{Catalog backend type}
@@ -13,6 +13,10 @@ ensure_extensions(backend, encrypted = FALSE)
 encrypted files requires the full crypto module from the httpfs
 extension on platforms where the built-in module is read-only
 (notably Windows).}
+
+\item{remote}{Whether the data path or catalog path is a remote URI, in
+which case httpfs handles the IO. Loading it up front beats relying on
+DuckDB's mid-statement autoload, which can fail.}
 }
 \value{
 Invisibly, \code{NULL}. Called for its side effect of loading (and, if

--- a/tests/testthat/test-multi-backend.R
+++ b/tests/testthat/test-multi-backend.R
@@ -88,6 +88,51 @@ test_that("build_attach_sql generates correct SQL for DuckDB backend", {
   expect_true(grepl("DATA_PATH '/data'", sql, fixed = TRUE))
 })
 
+test_that("build_attach_sql honors catalog_connection_string for DuckDB backend", {
+  sql <- ducklake:::build_attach_sql(
+    "my_lake",
+    "s3://bucket/data",
+    "duckdb",
+    "/lakes/my_lake.ducklake",
+    FALSE
+  )
+  expect_true(grepl("ATTACH 'ducklake:/lakes/my_lake.ducklake'", sql, fixed = TRUE))
+  expect_true(grepl("DATA_PATH 's3://bucket/data'", sql, fixed = TRUE))
+  expect_false(grepl("s3://bucket/data/my_lake.ducklake", sql, fixed = TRUE))
+
+  # NULL still derives the catalog path from lake_path
+  sql2 <- ducklake:::build_attach_sql("my_lake", "/data", "duckdb", NULL, FALSE)
+  expect_true(grepl("ducklake:/data/my_lake.ducklake", sql2, fixed = TRUE))
+})
+
+test_that("attach_ducklake refuses to write a duckdb catalog to object storage", {
+  skip_if_not_installed("duckdb")
+
+  expect_error(
+    attach_ducklake("remote_lake", lake_path = "s3://bucket/data"),
+    "catalog_connection_string"
+  )
+  expect_error(
+    attach_ducklake(
+      "remote_lake",
+      lake_path = "s3://bucket/data",
+      catalog_connection_string = "s3://bucket/remote_lake.ducklake"
+    ),
+    "object storage"
+  )
+
+  # read_only leaves direct remote attach available
+  sql <- ducklake:::build_attach_sql(
+    "remote_lake",
+    "s3://bucket/data",
+    "duckdb",
+    "s3://bucket/remote_lake.ducklake",
+    TRUE
+  )
+  expect_true(grepl("ducklake:s3://bucket/remote_lake.ducklake", sql, fixed = TRUE))
+  expect_true(grepl("READ_ONLY", sql))
+})
+
 test_that("build_attach_sql generates correct SQL for PostgreSQL backend", {
   sql <- ducklake:::build_attach_sql(
     "my_lake",
@@ -228,6 +273,63 @@ test_that("SQLite backend: create table, query, and time travel", {
     },
     finally = {
       unlink(temp_dir, recursive = TRUE)
+    }
+  )
+})
+
+# --- DuckDB backend with a split catalog/data layout ---
+
+test_that("duckdb backend: local catalog with separate data path round-trips", {
+  skip_if_no_ducklake()
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  catalog_dir <- tempfile("test_split_catalog")
+  data_dir <- tempfile("test_split_data")
+  backup_root <- tempfile("test_split_backup")
+  for (d in c(catalog_dir, data_dir, backup_root)) {
+    dir.create(d, showWarnings = FALSE, recursive = TRUE)
+  }
+  catalog_file <- file.path(catalog_dir, "split.ducklake")
+
+  tryCatch(
+    {
+      attach_ducklake(
+        "split_lake",
+        lake_path = data_dir,
+        catalog_connection_string = catalog_file
+      )
+
+      create_table(mtcars, "cars")
+
+      expect_true(file.exists(catalog_file))
+      parquet_files <- list.files(
+        data_dir,
+        pattern = "\\.parquet$",
+        recursive = TRUE
+      )
+      expect_gt(length(parquet_files), 0)
+
+      # Survives a full shutdown and re-attach with the same layout
+      detach_ducklake("split_lake", shutdown = TRUE)
+      attach_ducklake(
+        "split_lake",
+        lake_path = data_dir,
+        catalog_connection_string = catalog_file
+      )
+      result <- get_ducklake_table("cars") |> dplyr::collect()
+      expect_equal(nrow(result), 32)
+
+      # backup_ducklake() finds the catalog outside lake_path via the registry
+      backup_dir <- suppressMessages(
+        backup_ducklake("split_lake", lake_path = data_dir, backup_path = backup_root)
+      )
+      expect_true(file.exists(file.path(backup_dir, "split.ducklake")))
+
+      detach_ducklake("split_lake", shutdown = TRUE)
+    },
+    finally = {
+      unlink(c(catalog_dir, data_dir, backup_root), recursive = TRUE)
     }
   )
 })

--- a/vignettes/storage-and-backups.Rmd
+++ b/vignettes/storage-and-backups.Rmd
@@ -116,8 +116,15 @@ create_storage_secret(
 # instance metadata) -- no keys in code
 create_storage_secret("s3", provider = "credential_chain")
 
-# Then attach as usual
-attach_ducklake("shared_lake", lake_path = "s3://my-bucket/ducklake/data")
+# Then attach. With the default duckdb backend the catalog file must stay
+# on local disk (DuckDB cannot write a database file to object storage), so
+# name its location with catalog_connection_string; lake_path only sets
+# where the Parquet data goes.
+attach_ducklake(
+  "shared_lake",
+  lake_path = "s3://my-bucket/ducklake/data",
+  catalog_connection_string = "shared_lake.ducklake"
+)
 ```
 
 Secrets are in-memory by default and disappear with the session; pass


### PR DESCRIPTION
With `backend = "duckdb"`, `attach_ducklake()` derived the catalog file location from `lake_path`, so there was no way to say "catalog file on local disk, Parquet data at `s3://...`" even though raw SQL supports exactly that (`ATTACH 'ducklake:catalog.ducklake' (DATA_PATH 's3://...')`). The roxygen already documented `catalog_connection_string` for the duckdb backend; the code ignored it.

Changes:

- `catalog_connection_string` is now honored for the duckdb backend as the path for the `.ducklake` file, with `lake_path` acting purely as `DATA_PATH` when both are given. The default (derive from `lake_path`) is unchanged.
- `attach_ducklake()` errors early when the duckdb catalog would land on object storage, which DuckDB cannot write and which previously died with a confusing IO error. `read_only = TRUE` stays open for direct remote attach of an existing catalog.
- httpfs is loaded at attach time whenever a remote path is involved, with the package's usual install messaging, instead of relying on DuckDB's mid-statement autoload (see #43 for how that can go).
- `backup_ducklake()` reads the catalog location from the lake registry, so a split-layout lake backs up and reattaches correctly.
- The `create_storage_secret()` example and the storage vignette showed an S3 `lake_path` with the default backend, which would have put the catalog file itself on S3. Both now show the split layout.

New tests cover the SQL generation, the guardrail, and an end-to-end split-layout round trip including backup.

Note: this PR's diff includes the housekeeping commits from #47 until that merges; merging #47 first shrinks this to its own changes.

Fixes #44