### PR TITLE
Add meta_encryption_key to encrypt the catalog database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,9 @@
   MERGE + DELETE in one transaction), no MERGE RETURNING, `ALTER COLUMN
   SET TYPE` allows widening promotions only, and `ADD COLUMN ... DEFAULT`
   backfills existing rows.
+- ATTACH behavior confirmed empirically (2026-08-27): `META_`-prefixed
+  ATTACH options are forwarded to the catalog database, so
+  `META_ENCRYPTION_KEY` encrypts a duckdb-format catalog
+  (`meta_encryption_key` in `attach_ducklake()`). ATTACH cannot take bound
+  parameters -- DuckLake re-serializes forwarded options into an internal
+  second ATTACH -- so option values interpolate via `quote_sql()`.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
     duckdb (>= 1.5.1)
 Suggests:
     admiral,
+    askpass,
     DiagrammeR,
     fs,
     ggplot2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # ducklake (development version)
 
+* New `meta_encryption_key` argument in `attach_ducklake()` encrypts the
+  DuckDB catalog database file itself with AES-256-GCM (DuckLake forwards
+  `META_`-prefixed options to the metadata catalog). The key is set when
+  the catalog is created and required on every later attach. The catalog
+  is where `encrypted = TRUE` stores its Parquet keys, so encrypting it
+  closes that loop; pass `askpass::askpass()` as the value to be prompted
+  instead of writing the key in code (#46, suggested by @frankpopham).
+
 * The `"duckdb"` backend now honors `catalog_connection_string` as the path
   for its catalog file, so a single-writer lake can keep the catalog on
   local disk while `lake_path` points at object storage. The documentation

--- a/R/attach_ducklake.R
+++ b/R/attach_ducklake.R
@@ -45,6 +45,17 @@
 #'   loaded automatically: on some platforms (notably Windows) DuckDB's
 #'   built-in crypto module is read-only and httpfs provides the writer.
 #'   Default `FALSE`.
+#' @param meta_encryption_key Optional key that encrypts the catalog
+#'   database file itself, with AES-256-GCM (`"duckdb"` backend only; the
+#'   `META_` prefix is how DuckLake forwards the option to the metadata
+#'   catalog). The key takes effect when the catalog is first created -- an
+#'   existing unencrypted catalog cannot be encrypted after the fact -- and
+#'   the same key is required on every later attach, with no recovery if it
+#'   is lost. Pairs naturally with `encrypted`, whose Parquet keys are
+#'   stored in the catalog. Pass `askpass::askpass()` to be prompted rather
+#'   than putting the key in code. The key is interpolated into the
+#'   `ATTACH` statement text, so it can surface where statements are logged
+#'   or profiled.
 #' @param snapshot_version Optional snapshot id. Attaches the lake pinned to
 #'   that snapshot: queries see the lake exactly as it was then, and writes
 #'   are rejected. Mutually exclusive with `snapshot_time`.
@@ -148,6 +159,15 @@
 #' # Encrypted Parquet files (keys live in the catalog); needs httpfs
 #' attach_ducklake("secure_lake", lake_path = "path/to/lake", encrypted = TRUE)
 #'
+#' # Encrypt the catalog database too -- it is where the Parquet keys live.
+#' # askpass prompts for the key so it never sits in code.
+#' attach_ducklake(
+#'   "secure_lake",
+#'   lake_path = "path/to/lake",
+#'   encrypted = TRUE,
+#'   meta_encryption_key = askpass::askpass("Catalog encryption key")
+#' )
+#'
 #' # A frozen view of the lake as of snapshot 12, e.g. to reproduce a report
 #' attach_ducklake("lake_v12", lake_path = "path/to/lake", snapshot_version = 12)
 #' }
@@ -158,6 +178,7 @@ attach_ducklake <- function(ducklake_name, lake_path,
                              override_data_path = FALSE,
                              data_inlining_row_limit = NULL,
                              encrypted = FALSE,
+                             meta_encryption_key = NULL,
                              snapshot_version = NULL,
                              snapshot_time = NULL) {
   backend <- match.arg(backend)
@@ -167,6 +188,23 @@ attach_ducklake <- function(ducklake_name, lake_path,
     cli::cli_abort(
       "Provide only one of {.arg snapshot_version} and {.arg snapshot_time}."
     )
+  }
+
+  if (!is.null(meta_encryption_key)) {
+    if (backend != "duckdb") {
+      cli::cli_abort(c(
+        "{.arg meta_encryption_key} is only supported for the {.val duckdb} backend.",
+        "i" = "It encrypts the DuckDB catalog database file. A {.val {backend}} catalog is encrypted with that database's own tools."
+      ))
+    }
+    if (!is.character(meta_encryption_key) ||
+        length(meta_encryption_key) != 1 ||
+        is.na(meta_encryption_key) ||
+        !nzchar(meta_encryption_key)) {
+      cli::cli_abort(
+        "{.arg meta_encryption_key} must be a single, non-empty string."
+      )
+    }
   }
 
   if (missing(lake_path) || is.null(lake_path)) {
@@ -232,7 +270,7 @@ attach_ducklake <- function(ducklake_name, lake_path,
   # Load required extensions (ducklake + backend-specific + crypto/remote IO)
   ensure_extensions(
     backend,
-    encrypted = encrypted,
+    encrypted = encrypted || !is.null(meta_encryption_key),
     remote = is_remote_path(lake_path) ||
       (!is.null(catalog_connection_string) &&
          is_remote_path(catalog_connection_string))
@@ -244,6 +282,7 @@ attach_ducklake <- function(ducklake_name, lake_path,
                                   override_data_path,
                                   data_inlining_row_limit,
                                   encrypted,
+                                  meta_encryption_key,
                                   snapshot_version,
                                   snapshot_time)
   db_execute(attach_sql)
@@ -326,6 +365,7 @@ ensure_extensions <- function(backend, encrypted = FALSE, remote = FALSE) {
 #' @param override_data_path Whether to add OVERRIDE_DATA_PATH TRUE
 #' @param data_inlining_row_limit Optional integer for DATA_INLINING_ROW_LIMIT
 #' @param encrypted Whether to add ENCRYPTED TRUE
+#' @param meta_encryption_key Optional key for META_ENCRYPTION_KEY
 #' @param snapshot_version Optional snapshot id for SNAPSHOT_VERSION
 #' @param snapshot_time Optional timestamp for SNAPSHOT_TIME
 #'
@@ -336,6 +376,7 @@ build_attach_sql <- function(ducklake_name, lake_path, backend,
                               override_data_path = FALSE,
                               data_inlining_row_limit = NULL,
                               encrypted = FALSE,
+                              meta_encryption_key = NULL,
                               snapshot_version = NULL,
                               snapshot_time = NULL) {
   connection_string <- switch(backend,
@@ -372,6 +413,13 @@ build_attach_sql <- function(ducklake_name, lake_path, backend,
 
   if (encrypted) {
     options <- c(options, "ENCRYPTED TRUE")
+  }
+
+  if (!is.null(meta_encryption_key)) {
+    options <- c(
+      options,
+      sprintf("META_ENCRYPTION_KEY %s", quote_sql(meta_encryption_key))
+    )
   }
 
   if (!is.null(snapshot_version)) {

--- a/man/attach_ducklake.Rd
+++ b/man/attach_ducklake.Rd
@@ -13,6 +13,7 @@ attach_ducklake(
   override_data_path = FALSE,
   data_inlining_row_limit = NULL,
   encrypted = FALSE,
+  meta_encryption_key = NULL,
   snapshot_version = NULL,
   snapshot_time = NULL
 )
@@ -61,6 +62,18 @@ lake keeps the setting it was created with. The httpfs extension is
 loaded automatically: on some platforms (notably Windows) DuckDB's
 built-in crypto module is read-only and httpfs provides the writer.
 Default \code{FALSE}.}
+
+\item{meta_encryption_key}{Optional key that encrypts the catalog
+database file itself, with AES-256-GCM (\code{"duckdb"} backend only; the
+\code{META_} prefix is how DuckLake forwards the option to the metadata
+catalog). The key takes effect when the catalog is first created -- an
+existing unencrypted catalog cannot be encrypted after the fact -- and
+the same key is required on every later attach, with no recovery if it
+is lost. Pairs naturally with \code{encrypted}, whose Parquet keys are
+stored in the catalog. Pass \code{askpass::askpass()} to be prompted rather
+than putting the key in code. The key is interpolated into the
+\code{ATTACH} statement text, so it can surface where statements are logged
+or profiled.}
 
 \item{snapshot_version}{Optional snapshot id. Attaches the lake pinned to
 that snapshot: queries see the lake exactly as it was then, and writes
@@ -173,6 +186,15 @@ attach_ducklake(
 
 # Encrypted Parquet files (keys live in the catalog); needs httpfs
 attach_ducklake("secure_lake", lake_path = "path/to/lake", encrypted = TRUE)
+
+# Encrypt the catalog database too -- it is where the Parquet keys live.
+# askpass prompts for the key so it never sits in code.
+attach_ducklake(
+  "secure_lake",
+  lake_path = "path/to/lake",
+  encrypted = TRUE,
+  meta_encryption_key = askpass::askpass("Catalog encryption key")
+)
 
 # A frozen view of the lake as of snapshot 12, e.g. to reproduce a report
 attach_ducklake("lake_v12", lake_path = "path/to/lake", snapshot_version = 12)

--- a/man/build_attach_sql.Rd
+++ b/man/build_attach_sql.Rd
@@ -13,6 +13,7 @@ build_attach_sql(
   override_data_path = FALSE,
   data_inlining_row_limit = NULL,
   encrypted = FALSE,
+  meta_encryption_key = NULL,
   snapshot_version = NULL,
   snapshot_time = NULL
 )
@@ -34,6 +35,8 @@ the duckdb backend, an optional path for the catalog file}
 \item{data_inlining_row_limit}{Optional integer for DATA_INLINING_ROW_LIMIT}
 
 \item{encrypted}{Whether to add ENCRYPTED TRUE}
+
+\item{meta_encryption_key}{Optional key for META_ENCRYPTION_KEY}
 
 \item{snapshot_version}{Optional snapshot id for SNAPSHOT_VERSION}
 

--- a/tests/testthat/test-catalog-encryption.R
+++ b/tests/testthat/test-catalog-encryption.R
@@ -1,0 +1,93 @@
+# Tests for catalog encryption (META_ENCRYPTION_KEY)
+
+test_that("build_attach_sql renders META_ENCRYPTION_KEY with escaping", {
+  sql <- build_attach_sql(
+    "lake", "/data", "duckdb", NULL,
+    read_only = FALSE, meta_encryption_key = "k'x"
+  )
+  expect_match(sql, "META_ENCRYPTION_KEY 'k''x'", fixed = TRUE)
+
+  # Absent when NULL
+  sql2 <- build_attach_sql("lake", "/data", "duckdb", NULL, read_only = FALSE)
+  expect_false(grepl("META_ENCRYPTION_KEY", sql2))
+})
+
+test_that("attach_ducklake validates meta_encryption_key", {
+  expect_error(
+    attach_ducklake(
+      "enc_lake",
+      lake_path = tempdir(),
+      backend = "sqlite",
+      catalog_connection_string = "metadata.sqlite",
+      meta_encryption_key = "k"
+    ),
+    "duckdb"
+  )
+  expect_error(
+    attach_ducklake("enc_lake", lake_path = tempdir(), meta_encryption_key = ""),
+    "non-empty"
+  )
+  expect_error(
+    attach_ducklake(
+      "enc_lake",
+      lake_path = tempdir(),
+      meta_encryption_key = NA_character_
+    ),
+    "non-empty"
+  )
+  expect_error(
+    attach_ducklake(
+      "enc_lake",
+      lake_path = tempdir(),
+      meta_encryption_key = c("a", "b")
+    ),
+    "non-empty"
+  )
+})
+
+test_that("a catalog encrypted with meta_encryption_key round-trips", {
+  skip_if_no_ducklake()
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake_dir <- tempfile("test_enc_catalog")
+  dir.create(lake_dir, showWarnings = FALSE, recursive = TRUE)
+
+  tryCatch(
+    {
+      attach_ducklake(
+        "vault_lake",
+        lake_path = lake_dir,
+        meta_encryption_key = "test-key"
+      )
+      create_table(mtcars, "cars")
+      detach_ducklake("vault_lake", shutdown = TRUE)
+
+      # Without the key DuckDB refuses to open the catalog; same for a
+      # wrong key. The wording is DuckDB's, so no message assertions.
+      expect_error(
+        attach_ducklake("vault_lake", lake_path = lake_dir)
+      )
+      expect_error(
+        attach_ducklake(
+          "vault_lake",
+          lake_path = lake_dir,
+          meta_encryption_key = "wrong-key"
+        )
+      )
+
+      attach_ducklake(
+        "vault_lake",
+        lake_path = lake_dir,
+        meta_encryption_key = "test-key"
+      )
+      result <- get_ducklake_table("cars") |> dplyr::collect()
+      expect_equal(nrow(result), 32)
+
+      detach_ducklake("vault_lake", shutdown = TRUE)
+    },
+    finally = {
+      unlink(lake_dir, recursive = TRUE)
+    }
+  )
+})


### PR DESCRIPTION
New `meta_encryption_key` argument for `attach_ducklake()`. DuckLake forwards `META_`-prefixed ATTACH options to the metadata catalog, so `META_ENCRYPTION_KEY 'key'` reaches DuckDB's database encryption (AES-256-GCM, available since engine 1.4). The catalog is where `encrypted = TRUE` stores its per-file Parquet keys, which is the motivation in #46: encrypting the catalog protects those keys.

Design notes:

- The key is a plain string argument. For interactive use the docs and example show `meta_encryption_key = askpass::askpass()` at the call site, which keeps the key out of code without a prompting code path in the package; askpass joins Suggests. (The issue floated binding the key as a DBI parameter, but ATTACH cannot be parameterized, and DuckLake re-serializes forwarded options into an internal second ATTACH anyway, so the key is interpolated with the same escaping used for `CREATE SECRET` values.)
- duckdb backend only; postgres/sqlite/mysql catalogs are encrypted with their own tools, and the argument errors early there.
- The key applies when the catalog is first created, is required on every later attach, and has no recovery if lost; an existing plain catalog cannot be encrypted after the fact. All documented.

Verified end-to-end in the new test file: an encrypted catalog refuses to open with no key or a wrong key, and round-trips data with the right one.

Stacked on #48 (same `ensure_extensions()` call site). Merge #48 first, without deleting its branch, then retarget this PR to main before deleting.

Fixes #46