### PR TITLE
Run create_table() and replace_table() pipelines inside DuckDB

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # ducklake (development version)
 
+* `create_table()` and `replace_table()` now run dplyr pipelines inside
+  DuckDB. A lazy table on the package's connection is written with
+  `CREATE TABLE ... AS`; a replacement is materialized in DuckDB's
+  temporary storage first (the query may read the table it replaces) and
+  the table is rebuilt from it. Rows no longer pass through R, so silver
+  and gold layers derived from large bronze tables cost DuckDB memory, not
+  R memory. Column comments follow the data: each output column keeps the
+  comment of the same-named column in the tables the query reads, so
+  variable labels survive a pipeline as they did through the old collect
+  path. Data frames, and lazy tables on other connections, load as before.
+
 * `replace_table()` and `restore_table_version()` now carry a table's
   metadata over to the rewritten table: the table comment, column comments
   (and so variable labels), partition keys, sort order, and table-scoped

--- a/R/create_table.R
+++ b/R/create_table.R
@@ -4,14 +4,21 @@
 #'   - A URL (http:// or https://)
 #'   - A file path (e.g., "data.csv", "data.parquet")
 #'   - An R data.frame or tibble
-#'   - A lazy table (tbl_duckdb_connection or tbl_lazy)
+#'   - A lazy table (tbl_duckdb_connection or tbl_lazy). A lazy table on
+#'     the package's connection, such as a dplyr pipeline built on
+#'     [get_ducklake_table()], is written with `CREATE TABLE ... AS` inside
+#'     DuckDB, so its rows never pass through R. A lazy table on another
+#'     connection is collected first.
 #' @param table_name Name of the new table
-#' @param labels When `TRUE` (the default) and the data has haven/labelled
-#'   variable labels (`label` attributes on columns), store them in the
-#'   lake as column comments -- in the same transaction as the table
-#'   creation, so both land as one snapshot. Collecting the table later
-#'   restores the labels (see [get_table_comments()]), and every other
-#'   client of the lake can read them too. Set to `FALSE` to skip.
+#' @param labels When `TRUE` (the default), store variable labels in the
+#'   lake as column comments, in the same transaction as the table
+#'   creation, so both land as one snapshot. For a data frame the labels
+#'   are its haven/labelled `label` attributes; for a lazy table, each
+#'   output column keeps the comment of the same-named column in the tables
+#'   the query reads, so labels follow the data through a pipeline (a
+#'   renamed or derived column starts without one). Collecting the table
+#'   later restores the labels (see [get_table_comments()]), and every
+#'   other client of the lake can read them too. Set to `FALSE` to skip.
 #'
 #' @returns Invisibly, `NULL`. Called for its side effect of creating the
 #'   table in the lake.
@@ -31,7 +38,8 @@
 #' utils::write.csv(mtcars, csv_path, row.names = FALSE)
 #' create_table(csv_path, "cars_from_csv")
 #'
-#' # From a lazy table (pipe-friendly)
+#' # From a lazy table: the query runs inside DuckDB and writes straight
+#' # into the lake, without collecting into R
 #' get_ducklake_table("cars") |>
 #'   dplyr::filter(cyl > 4) |>
 #'   create_table("big_cars")
@@ -46,9 +54,12 @@
 #' detach_ducklake("create_lake", shutdown = TRUE)
 #' unlink(lake_dir, recursive = TRUE)
 create_table <- function(data_source, table_name, labels = TRUE) {
-  # Handle lazy tables (tbl_duckdb_connection, tbl_lazy)
   if (inherits(data_source, "tbl_lazy")) {
-    # Materialize the lazy table to a data.frame
+    conn <- get_ducklake_connection()
+    if (same_connection(data_source, conn)) {
+      return(create_table_from_query(data_source, table_name, labels, conn))
+    }
+    # A lazy table on another connection has to come through R
     data_source <- dplyr::collect(data_source)
   }
 
@@ -196,4 +207,114 @@ store_column_labels <- function(table_name, column_labels, conn) {
     )
   }
   invisible(NULL)
+}
+
+#' Is a lazy table backed by this connection?
+#' @noRd
+same_connection <- function(tbl, conn) {
+  remote <- tryCatch(dbplyr::remote_con(tbl), error = function(e) NULL)
+  !is.null(remote) && identical(remote, conn)
+}
+
+#' Create a table from a lazy query, inside DuckDB
+#'
+#' `CREATE TABLE ... AS` with the rendered dbplyr SQL, so the rows never
+#' pass through R. Column comments inherited from the source tables are
+#' stored in the same transaction, as the data-frame path does for labels.
+#'
+#' @param .data A lazy table on `conn`.
+#' @param table_name Name of the new table.
+#' @param labels Whether to carry source column comments over.
+#' @param conn The package connection.
+#' @returns Invisibly, `NULL`.
+#' @noRd
+create_table_from_query <- function(.data, table_name, labels, conn) {
+  column_comments <- if (isTRUE(labels)) {
+    source_column_comments(.data, conn)
+  } else {
+    character()
+  }
+  sql <- dbplyr::sql_render(.data, conn)
+
+  own_txn <- length(column_comments) > 0 && !in_transaction(conn)
+  committed <- FALSE
+  if (own_txn) {
+    DBI::dbExecute(conn, "BEGIN TRANSACTION;")
+    on.exit(
+      if (!committed) {
+        tryCatch(DBI::dbExecute(conn, "ROLLBACK;"), error = function(e) NULL)
+      },
+      add = TRUE
+    )
+  }
+
+  db_execute(
+    sprintf("CREATE TABLE %s AS\n%s;", quote_ident(table_name, conn), sql),
+    conn = conn
+  )
+  store_column_labels(table_name, column_comments, conn)
+
+  if (own_txn) {
+    DBI::dbExecute(conn, "COMMIT;")
+    committed <- TRUE
+  }
+  if (length(column_comments) > 0) {
+    cli::cli_inform(
+      "Stored {length(column_comments)} column label{?s} as column comment{?s}."
+    )
+  }
+
+  invisible(NULL)
+}
+
+#' Column comments a query's output columns inherit from the tables it reads
+#'
+#' An output column keeps the comment of a same-named column in any base
+#' table of the query (first source wins); renamed or derived columns get
+#' none. The table a [get_ducklake_table()] pipeline started from is always
+#' consulted, even when the built query hides it behind raw SQL (a
+#' time-travel read, for example).
+#'
+#' @param .data A lazy table.
+#' @param conn A DBI connection.
+#' @returns A named character vector, column name to comment.
+#' @noRd
+source_column_comments <- function(.data, conn) {
+  out_cols <- colnames(.data)
+
+  sources <- attr(.data, "ducklake_table_name", exact = TRUE)
+  bases <- tryCatch(
+    query_base_tables(dbplyr::sql_build(.data)),
+    error = function(e) character()
+  )
+  bases <- vapply(bases[!is.na(bases)], table_ref_name, character(1))
+  sources <- unique(c(sources, bases[!is.na(bases)]))
+
+  comments <- character()
+  for (src in sources) {
+    found <- tryCatch(get_table_comments(src), error = function(e) NULL)
+    if (is.null(found) || nrow(found) == 0) {
+      next
+    }
+    found <- found[
+      found$object_type == "column" & found$column_name %in% out_cols &
+        !(found$column_name %in% names(comments)), ,
+      drop = FALSE
+    ]
+    comments[found$column_name] <- found$comment
+  }
+  comments
+}
+
+#' Reduce a base-table reference from `query_base_tables()` to a name
+#'
+#' dbplyr hands back a table path (`cars`, `"main"."cars"`) or, for a
+#' dotted name the duckdb driver wrapped in SQL, `FROM main.cars`. Returns
+#' the name with its qualification and case intact, or `NA` for anything
+#' that is not a plain identifier path.
+#' @noRd
+table_ref_name <- function(x) {
+  x <- gsub('"', "", as.character(x)[[1]])
+  x <- sub("^FROM\\s+", "", x)
+  if (grepl("^[A-Za-z_][A-Za-z0-9_.]*$", x)) x else NA_character_
 }

--- a/R/merge_into.R
+++ b/R/merge_into.R
@@ -55,7 +55,7 @@
 #'   ([add_table_column()] and friends): metadata-only changes that rewrite
 #'   nothing.
 #' - For bulk transformations that touch most rows, use [replace_table()]. It
-#'   collects the transformed data into R and rewrites the whole table --
+#'   rewrites the whole table inside DuckDB --
 #'   heavier than the row operations, and it resets the row lineage that the
 #'   in-place operations preserve in the change feed.
 #'

--- a/R/replace_table.R
+++ b/R/replace_table.R
@@ -9,12 +9,14 @@
 #' @export
 #'
 #' @details
-#' This function is designed for schema changes or bulk transformations that should
-#' create a new versioned snapshot. It:
-#' 1. Collects the transformed data
-#' 2. Drops the existing table
-#' 3. Creates a new table with the updated schema/data
-#' 4. Puts back the metadata DuckLake keeps against the table
+#' This function is designed for bulk transformations that should create a
+#' new versioned snapshot. A dplyr pipeline on the package's connection
+#' runs inside DuckDB: its result is materialized in DuckDB's temporary
+#' storage (the query may read the table being replaced), the table is
+#' dropped and recreated from it, and the metadata DuckLake keeps against
+#' the table is put back. No rows pass through R. A data frame, or a lazy
+#' table on another connection, is loaded the way [create_table()] loads
+#' it.
 #'
 #' The drop and create run atomically: when no transaction is open,
 #' `replace_table()` wraps them in one of its own, so a failed create never
@@ -97,15 +99,6 @@ replace_table <- function(.data, table_name, .quiet = TRUE) {
     cli::cli_inform("Replacing table {.val {table_name}}...")
   }
 
-  # Collect the transformed data
-  new_data <- dplyr::collect(.data)
-
-  if (!.quiet) {
-    cli::cli_inform(
-      "Collected {nrow(new_data)} row{?s} with {ncol(new_data)} column{?s}."
-    )
-  }
-
   conn <- get_ducklake_connection()
 
   # DROP + CREATE assigns a new table id, and DuckLake keys comments,
@@ -113,12 +106,31 @@ replace_table <- function(.data, table_name, .quiet = TRUE) {
   # them first so they can be put back on the new table
   meta <- capture_table_metadata(table_name, conn = conn)
 
-  prepared <- prepare_data_frame(new_data)
-  temp_view_name <- register_temp_view(prepared$data, table_name, conn)
-  on.exit(
-    duckdb::duckdb_unregister(get_ducklake_connection(), temp_view_name),
-    add = TRUE
-  )
+  if (inherits(.data, "tbl_lazy") && same_connection(.data, conn)) {
+    # In-database path: the query's result waits in a temporary table
+    # while the target is rebuilt, since the query may read the target
+    comments <- source_column_comments(.data, conn)
+    source_ref <- materialize_query(.data, table_name, conn)
+    on.exit(
+      try(db_execute(sprintf("DROP TABLE IF EXISTS %s;", source_ref), conn = conn), silent = TRUE),
+      add = TRUE
+    )
+  } else {
+    # Data frames, and lazy tables on other connections, come through R
+    prepared <- prepare_data_frame(dplyr::collect(.data))
+    comments <- prepared$labels
+    temp_view_name <- register_temp_view(prepared$data, table_name, conn)
+    source_ref <- quote_ident(temp_view_name, conn)
+    on.exit(
+      duckdb::duckdb_unregister(get_ducklake_connection(), temp_view_name),
+      add = TRUE
+    )
+  }
+
+  if (!.quiet) {
+    n <- DBI::dbGetQuery(conn, sprintf("SELECT count(*) AS n FROM %s", source_ref))$n
+    cli::cli_inform("Prepared {n} row{?s} for {.val {table_name}}.")
+  }
 
   # The drop and create must land together: outside a transaction they
   # autocommit separately, so a failed create would leave the table gone.
@@ -128,35 +140,18 @@ replace_table <- function(.data, table_name, .quiet = TRUE) {
   committed <- FALSE
   if (own_txn) {
     DBI::dbExecute(conn, "BEGIN TRANSACTION;")
+    # Runs before the cleanup handlers above: DuckDB temp tables are
+    # transactional, so a rollback after the temp DROP would bring the
+    # temporary copy back
     on.exit(
       if (!committed) {
         tryCatch(DBI::dbExecute(conn, "ROLLBACK;"), error = function(e) NULL)
       },
-      add = TRUE
+      add = TRUE, after = FALSE
     )
   }
 
-  quoted_table <- quote_ident(table_name, conn)
-  quoted_view <- quote_ident(temp_view_name, conn)
-
-  # Drop the existing table
-  db_execute(sprintf("DROP TABLE IF EXISTS %s", quoted_table), conn = conn)
-
-  # Create the table empty, put the partition and sort keys on it, then
-  # insert: DuckLake refuses to alter a table that already holds inlined
-  # rows from the open transaction, and keys set first shape the new files
-  db_execute(
-    sprintf("CREATE TABLE %s AS SELECT * FROM %s LIMIT 0;", quoted_table, quoted_view),
-    conn = conn
-  )
-  columns <- names(prepared$data)
-  reapply_table_keys(meta, columns, conn)
-  db_execute(
-    sprintf("INSERT INTO %s SELECT * FROM %s;", quoted_table, quoted_view),
-    conn = conn
-  )
-  store_column_labels(table_name, prepared$labels, conn)
-  reapply_table_comments(meta, columns, names(prepared$labels), conn)
+  rebuild_table_from(table_name, source_ref, meta, comments, conn)
 
   if (own_txn) {
     DBI::dbExecute(conn, "COMMIT;")

--- a/R/rows_operations.R
+++ b/R/rows_operations.R
@@ -31,7 +31,7 @@
 #'   ([add_table_column()] and friends): metadata-only changes that rewrite
 #'   nothing.
 #' - For bulk transformations that touch most rows, use [replace_table()]. It
-#'   collects the transformed data into R and rewrites the whole table --
+#'   rewrites the whole table inside DuckDB --
 #'   heavier than the row operations, and it resets the row lineage that the
 #'   in-place operations preserve in the change feed.
 #'
@@ -123,7 +123,7 @@ rows_update.tbl_ducklake <- function(x, y, by = NULL, ...,
 #'   ([add_table_column()] and friends): metadata-only changes that rewrite
 #'   nothing.
 #' - For bulk transformations that touch most rows, use [replace_table()]. It
-#'   collects the transformed data into R and rewrites the whole table --
+#'   rewrites the whole table inside DuckDB --
 #'   heavier than the row operations, and it resets the row lineage that the
 #'   in-place operations preserve in the change feed.
 #'
@@ -194,7 +194,7 @@ rows_insert.tbl_ducklake <- function(x, y, by = NULL, ...,
 #'   ([add_table_column()] and friends): metadata-only changes that rewrite
 #'   nothing.
 #' - For bulk transformations that touch most rows, use [replace_table()]. It
-#'   collects the transformed data into R and rewrites the whole table --
+#'   rewrites the whole table inside DuckDB --
 #'   heavier than the row operations, and it resets the row lineage that the
 #'   in-place operations preserve in the change feed.
 #'
@@ -268,7 +268,7 @@ rows_delete.tbl_ducklake <- function(x, y, by = NULL, ...,
 #'   ([add_table_column()] and friends): metadata-only changes that rewrite
 #'   nothing.
 #' - For bulk transformations that touch most rows, use [replace_table()]. It
-#'   collects the transformed data into R and rewrites the whole table --
+#'   rewrites the whole table inside DuckDB --
 #'   heavier than the row operations, and it resets the row lineage that the
 #'   in-place operations preserve in the change feed.
 #'

--- a/R/schema_evolution.R
+++ b/R/schema_evolution.R
@@ -3,7 +3,7 @@
 #' Adds a column in place with `ALTER TABLE ... ADD COLUMN`. This is a
 #' metadata-only change: no data files are rewritten, history is preserved,
 #' and earlier snapshots still show the old schema. Compare
-#' [replace_table()], which collects the table into R and rewrites it.
+#' [replace_table()], which rewrites the whole table.
 #'
 #' @param table_name The table to change.
 #' @param column_name Name of the new column.

--- a/R/table_metadata.R
+++ b/R/table_metadata.R
@@ -190,6 +190,71 @@ reapply_table_options <- function(meta, conn = get_ducklake_connection()) {
   invisible(NULL)
 }
 
+#' Rebuild a table from a copy of its new contents, inside the open transaction
+#'
+#' The sequence DuckLake accepts in one transaction: drop, create empty
+#' with the copy's schema, put the partition and sort keys on, insert, then
+#' comment. `source_ref` is a quoted reference to the copy (a registered
+#' data-frame view or a temporary table).
+#'
+#' @param table_name The table to rebuild.
+#' @param source_ref Quoted SQL reference to the new contents.
+#' @param meta The list from `capture_table_metadata()`.
+#' @param comments Named character vector of column comments to store
+#'   first (labels from a data frame, or comments inherited from source
+#'   tables); captured comments fill the remaining columns.
+#' @param conn A DBI connection.
+#' @returns Invisibly, the column names of the rebuilt table.
+#' @noRd
+rebuild_table_from <- function(table_name, source_ref, meta, comments,
+                               conn = get_ducklake_connection()) {
+  quoted <- quote_ident(table_name, conn)
+  columns <- names(DBI::dbGetQuery(
+    conn, sprintf("SELECT * FROM %s LIMIT 0", source_ref)
+  ))
+
+  db_execute(sprintf("DROP TABLE IF EXISTS %s;", quoted), conn = conn)
+  db_execute(
+    sprintf("CREATE TABLE %s AS SELECT * FROM %s LIMIT 0;", quoted, source_ref),
+    conn = conn
+  )
+  reapply_table_keys(meta, columns, conn)
+  db_execute(
+    sprintf("INSERT INTO %s SELECT * FROM %s;", quoted, source_ref),
+    conn = conn
+  )
+  store_column_labels(table_name, comments, conn)
+  reapply_table_comments(meta, columns, names(comments), conn)
+
+  invisible(columns)
+}
+
+#' Materialize a lazy query into a temporary DuckDB table
+#'
+#' Used before a rewrite whose query may read the table being replaced:
+#' the copy lives in DuckDB's temp catalog (spilling to disk as needed), so
+#' nothing passes through R. The caller drops it, typically with
+#' `on.exit()`.
+#'
+#' @param .data A lazy table on `conn`.
+#' @param table_name The target table, used to derive the temp name.
+#' @param conn A DBI connection.
+#' @returns The quoted reference to the temporary table.
+#' @noRd
+materialize_query <- function(.data, table_name, conn = get_ducklake_connection()) {
+  name <- paste0("__ducklake_rewrite_", gsub("[^a-zA-Z0-9]", "_", table_name))
+  ref <- quote_ident(paste("temp", "main", name, sep = "."), conn)
+  db_execute(sprintf("DROP TABLE IF EXISTS %s;", ref), conn = conn)
+  db_execute(
+    sprintf(
+      "CREATE TEMP TABLE %s AS\n%s;",
+      quote_ident(name, conn), dbplyr::sql_render(.data, conn)
+    ),
+    conn = conn
+  )
+  ref
+}
+
 #' Rebuild `SET PARTITIONED BY` expressions from `get_table_partitions()` rows
 #'
 #' The catalog stores the transform separately from the column:

--- a/R/time_travel.R
+++ b/R/time_travel.R
@@ -334,9 +334,8 @@ restore_table_version <- function(table_name, version = NULL, timestamp = NULL,
   # dropped inside the transaction, time travel can no longer resolve it,
   # and CREATE OR REPLACE followed by INSERT in one transaction loses the
   # inserted rows in DuckLake 1.0
-  temp_table <- quote_ident(
-    paste0("__ducklake_restore_", gsub("[^a-zA-Z0-9]", "_", table_name)), conn
-  )
+  temp_name <- paste0("__ducklake_restore_", gsub("[^a-zA-Z0-9]", "_", table_name))
+  temp_table <- quote_ident(paste("temp", "main", temp_name, sep = "."), conn)
   db_execute(sprintf("DROP TABLE IF EXISTS %s;", temp_table), conn = conn)
   on.exit(
     try(
@@ -350,28 +349,13 @@ restore_table_version <- function(table_name, version = NULL, timestamp = NULL,
     db_execute(
       sprintf(
         "CREATE TEMP TABLE %s AS SELECT * FROM %s AT (%s);",
-        temp_table, quoted_table, at_clause
+        quote_ident(temp_name, conn), quoted_table, at_clause
       ),
       conn = conn
     )
-    columns <- names(DBI::dbGetQuery(
-      conn, sprintf("SELECT * FROM %s LIMIT 0", temp_table)
-    ))
 
     with_transaction(
-      {
-        db_execute(sprintf("DROP TABLE %s;", quoted_table), conn = conn)
-        db_execute(
-          sprintf("CREATE TABLE %s AS SELECT * FROM %s LIMIT 0;", quoted_table, temp_table),
-          conn = conn
-        )
-        reapply_table_keys(meta, columns, conn)
-        db_execute(
-          sprintf("INSERT INTO %s SELECT * FROM %s;", quoted_table, temp_table),
-          conn = conn
-        )
-        reapply_table_comments(meta, columns, conn = conn)
-      },
+      rebuild_table_from(table_name, temp_table, meta, character(), conn),
       author = author,
       commit_message = commit_message,
       conn = conn

--- a/README.Rmd
+++ b/README.Rmd
@@ -208,6 +208,7 @@ Check out the [pkgdown site](https://tgerke.github.io/ducklake-r/) for detailed 
 - **Variable labels survive the lake**: `create_table()` stores haven/labelled column labels as catalog comments and `collect()` restores them, so gtsummary and gt keep displaying them; `set_table_comment()`, `set_column_comments()`, and `get_table_comments()` manage documentation any client of the lake can read
 - **Views**: `create_view()` stores a dplyr pipeline as a SQL view in the lake — shared logic that always reads current data; `list_ducklake_tables()` shows what's there
 - **Tidyverse interface**: Familiar dplyr syntax for data manipulation
+- **In-database writes**: `create_table()` and `replace_table()` run dplyr pipelines inside DuckDB and write the result straight into the lake, so derived layers never pass through R memory
 - **Encryption**: Opt-in Parquet encryption with `attach_ducklake(encrypted = TRUE)`
 - **A write style for every job**: `rows_insert()`, `rows_update()`, `rows_delete()`, and `rows_upsert()` for incremental changes; `merge_into()` for conditional merges and staging-table syncs; `replace_table()` pipelines for bulk rewrites — all fully versioned
 - **Complete audit trails**: Who changed what, when, and why—suitable for regulated industries

--- a/man/add_table_column.Rd
+++ b/man/add_table_column.Rd
@@ -28,7 +28,7 @@ Invisibly returns \code{NULL}.
 Adds a column in place with \verb{ALTER TABLE ... ADD COLUMN}. This is a
 metadata-only change: no data files are rewritten, history is preserved,
 and earlier snapshots still show the old schema. Compare
-\code{\link[=replace_table]{replace_table()}}, which collects the table into R and rewrites it.
+\code{\link[=replace_table]{replace_table()}}, which rewrites the whole table.
 }
 \examples{
 \dontshow{if (ducklake_extension_available()) withAutoprint(\{ # examplesIf}

--- a/man/create_table.Rd
+++ b/man/create_table.Rd
@@ -12,17 +12,24 @@ create_table(data_source, table_name, labels = TRUE)
 \item A URL (http:// or https://)
 \item A file path (e.g., "data.csv", "data.parquet")
 \item An R data.frame or tibble
-\item A lazy table (tbl_duckdb_connection or tbl_lazy)
+\item A lazy table (tbl_duckdb_connection or tbl_lazy). A lazy table on
+the package's connection, such as a dplyr pipeline built on
+\code{\link[=get_ducklake_table]{get_ducklake_table()}}, is written with \verb{CREATE TABLE ... AS} inside
+DuckDB, so its rows never pass through R. A lazy table on another
+connection is collected first.
 }}
 
 \item{table_name}{Name of the new table}
 
-\item{labels}{When \code{TRUE} (the default) and the data has haven/labelled
-variable labels (\code{label} attributes on columns), store them in the
-lake as column comments -- in the same transaction as the table
-creation, so both land as one snapshot. Collecting the table later
-restores the labels (see \code{\link[=get_table_comments]{get_table_comments()}}), and every other
-client of the lake can read them too. Set to \code{FALSE} to skip.}
+\item{labels}{When \code{TRUE} (the default), store variable labels in the
+lake as column comments, in the same transaction as the table
+creation, so both land as one snapshot. For a data frame the labels
+are its haven/labelled \code{label} attributes; for a lazy table, each
+output column keeps the comment of the same-named column in the tables
+the query reads, so labels follow the data through a pipeline (a
+renamed or derived column starts without one). Collecting the table
+later restores the labels (see \code{\link[=get_table_comments]{get_table_comments()}}), and every
+other client of the lake can read them too. Set to \code{FALSE} to skip.}
 }
 \value{
 Invisibly, \code{NULL}. Called for its side effect of creating the
@@ -45,7 +52,8 @@ csv_path <- tempfile(fileext = ".csv")
 utils::write.csv(mtcars, csv_path, row.names = FALSE)
 create_table(csv_path, "cars_from_csv")
 
-# From a lazy table (pipe-friendly)
+# From a lazy table: the query runs inside DuckDB and writes straight
+# into the lake, without collecting into R
 get_ducklake_table("cars") |>
   dplyr::filter(cyl > 4) |>
   create_table("big_cars")

--- a/man/merge_into.Rd
+++ b/man/merge_into.Rd
@@ -83,7 +83,7 @@ rename columns, widen a type -- use the schema evolution family
 (\code{\link[=add_table_column]{add_table_column()}} and friends): metadata-only changes that rewrite
 nothing.
 \item For bulk transformations that touch most rows, use \code{\link[=replace_table]{replace_table()}}. It
-collects the transformed data into R and rewrites the whole table --
+rewrites the whole table inside DuckDB --
 heavier than the row operations, and it resets the row lineage that the
 in-place operations preserve in the change feed.
 }

--- a/man/replace_table.Rd
+++ b/man/replace_table.Rd
@@ -20,14 +20,14 @@ Invisibly returns NULL
 Replace a table with modified data and create a new snapshot
 }
 \details{
-This function is designed for schema changes or bulk transformations that should
-create a new versioned snapshot. It:
-\enumerate{
-\item Collects the transformed data
-\item Drops the existing table
-\item Creates a new table with the updated schema/data
-\item Puts back the metadata DuckLake keeps against the table
-}
+This function is designed for bulk transformations that should create a
+new versioned snapshot. A dplyr pipeline on the package's connection
+runs inside DuckDB: its result is materialized in DuckDB's temporary
+storage (the query may read the table being replaced), the table is
+dropped and recreated from it, and the metadata DuckLake keeps against
+the table is put back. No rows pass through R. A data frame, or a lazy
+table on another connection, is loaded the way \code{\link[=create_table]{create_table()}} loads
+it.
 
 The drop and create run atomically: when no transaction is open,
 \code{replace_table()} wraps them in one of its own, so a failed create never

--- a/man/rows_delete.Rd
+++ b/man/rows_delete.Rd
@@ -56,7 +56,7 @@ rename columns, widen a type -- use the schema evolution family
 (\code{\link[=add_table_column]{add_table_column()}} and friends): metadata-only changes that rewrite
 nothing.
 \item For bulk transformations that touch most rows, use \code{\link[=replace_table]{replace_table()}}. It
-collects the transformed data into R and rewrites the whole table --
+rewrites the whole table inside DuckDB --
 heavier than the row operations, and it resets the row lineage that the
 in-place operations preserve in the change feed.
 }

--- a/man/rows_insert.Rd
+++ b/man/rows_insert.Rd
@@ -56,7 +56,7 @@ rename columns, widen a type -- use the schema evolution family
 (\code{\link[=add_table_column]{add_table_column()}} and friends): metadata-only changes that rewrite
 nothing.
 \item For bulk transformations that touch most rows, use \code{\link[=replace_table]{replace_table()}}. It
-collects the transformed data into R and rewrites the whole table --
+rewrites the whole table inside DuckDB --
 heavier than the row operations, and it resets the row lineage that the
 in-place operations preserve in the change feed.
 }

--- a/man/rows_update.Rd
+++ b/man/rows_update.Rd
@@ -56,7 +56,7 @@ rename columns, widen a type -- use the schema evolution family
 (\code{\link[=add_table_column]{add_table_column()}} and friends): metadata-only changes that rewrite
 nothing.
 \item For bulk transformations that touch most rows, use \code{\link[=replace_table]{replace_table()}}. It
-collects the transformed data into R and rewrites the whole table --
+rewrites the whole table inside DuckDB --
 heavier than the row operations, and it resets the row lineage that the
 in-place operations preserve in the change feed.
 }

--- a/man/rows_upsert.Rd
+++ b/man/rows_upsert.Rd
@@ -50,7 +50,7 @@ rename columns, widen a type -- use the schema evolution family
 (\code{\link[=add_table_column]{add_table_column()}} and friends): metadata-only changes that rewrite
 nothing.
 \item For bulk transformations that touch most rows, use \code{\link[=replace_table]{replace_table()}}. It
-collects the transformed data into R and rewrites the whole table --
+rewrites the whole table inside DuckDB --
 heavier than the row operations, and it resets the row lineage that the
 in-place operations preserve in the change feed.
 }

--- a/tests/testthat/test-table-operations.R
+++ b/tests/testthat/test-table-operations.R
@@ -301,3 +301,155 @@ test_that("restore_table_version keeps comments and partition keys", {
   comments <- get_table_comments("restore_meta")
   expect_equal(comments$comment[comments$column_name %in% "id"], "Identifier")
 })
+
+test_that("create_table() from a lazy table runs in DuckDB and carries labels", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  df <- data.frame(
+    id = 1:5, v = c(10, 20, 30, 40, 50), grp = c("a", "b", "a", "b", "a")
+  )
+  attr(df$v, "label") <- "Value"
+  attr(df$grp, "label") <- "Group"
+  suppressMessages(create_table(df, "lazy_src"))
+
+  # The query must run as CREATE TABLE ... AS: collecting would be a bug
+  local_mocked_bindings(
+    collect = function(x, ...) stop("collected into R"),
+    .package = "dplyr"
+  )
+  suppressMessages(
+    get_ducklake_table("lazy_src") |>
+      dplyr::filter(v > 10) |>
+      dplyr::mutate(w = v * 2) |>
+      dplyr::select(id, v, w, category = grp) |>
+      create_table("lazy_dst")
+  )
+
+  result <- DBI::dbGetQuery(
+    get_ducklake_connection(), "SELECT * FROM lazy_dst ORDER BY id"
+  )
+  expect_equal(result$id, 2:5)
+  expect_equal(result$w, c(40, 60, 80, 100))
+
+  comments <- get_table_comments("lazy_dst")
+  expect_equal(comments$comment[comments$column_name %in% "v"], "Value")
+  # renamed and derived columns start without a label
+  expect_false("category" %in% comments$column_name)
+  expect_false("w" %in% comments$column_name)
+})
+
+test_that("create_table() from a join copies comments from every source", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  a <- data.frame(id = 1:3, x = c(1, 2, 3))
+  attr(a$x, "label") <- "X value"
+  b <- data.frame(id = 1:3, y = c(4, 5, 6))
+  attr(b$y, "label") <- "Y value"
+  suppressMessages({
+    create_table(a, "join_a")
+    create_table(b, "join_b")
+    get_ducklake_table("join_a") |>
+      dplyr::inner_join(get_ducklake_table("join_b"), by = "id") |>
+      create_table("join_ab")
+  })
+
+  comments <- get_table_comments("join_ab")
+  expect_equal(comments$comment[comments$column_name %in% "x"], "X value")
+  expect_equal(comments$comment[comments$column_name %in% "y"], "Y value")
+  expect_equal(nrow(dplyr::collect(get_ducklake_table("join_ab"))), 3)
+})
+
+test_that("lazy tables on another connection still load through R", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  other <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(other, shutdown = TRUE), add = TRUE)
+  DBI::dbWriteTable(other, "remote", data.frame(id = 1:4, v = c(1, 2, 3, 4)))
+
+  suppressMessages(
+    dplyr::tbl(other, "remote") |>
+      dplyr::filter(v > 1) |>
+      create_table("from_other")
+  )
+  expect_equal(nrow(dplyr::collect(get_ducklake_table("from_other"))), 3)
+
+  suppressMessages(dplyr::tbl(other, "remote") |> replace_table("from_other"))
+  expect_equal(nrow(dplyr::collect(get_ducklake_table("from_other"))), 4)
+})
+
+test_that("replace_table() from a lazy table rewrites inside DuckDB", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  df <- data.frame(id = 1:6, grp = rep(c("a", "b"), 3), v = 1:6 * 10)
+  attr(df$v, "label") <- "Value"
+  suppressMessages({
+    create_table(df, "inplace")
+    set_table_partitioning("inplace", "grp")
+  })
+
+  local_mocked_bindings(
+    collect = function(x, ...) stop("collected into R"),
+    .package = "dplyr"
+  )
+  suppressMessages(
+    get_ducklake_table("inplace") |>
+      dplyr::filter(id > 2) |>
+      dplyr::mutate(w = v * 2) |>
+      replace_table("inplace")
+  )
+
+  conn <- get_ducklake_connection()
+  result <- DBI::dbGetQuery(conn, "SELECT * FROM inplace ORDER BY id")
+  expect_equal(result$id, 3:6)
+  expect_equal(result$w, c(60, 80, 100, 120))
+  comments <- get_table_comments("inplace")
+  expect_equal(comments$comment[comments$column_name %in% "v"], "Value")
+  expect_equal(get_table_partitions("inplace")$column_name, "grp")
+
+  # The temporary copy of the result is gone
+  temp_tables <- DBI::dbGetQuery(
+    conn, "SELECT table_name FROM duckdb_tables() WHERE temporary"
+  )
+  expect_equal(nrow(temp_tables), 0)
+})
+
+test_that("replace_table() from a lazy table inside with_transaction() is one snapshot", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  create_table(data.frame(id = 1:3, v = c(1, 2, 3)), "txn_lazy")
+  before <- nrow(list_table_snapshots())
+
+  suppressMessages(with_transaction(
+    get_ducklake_table("txn_lazy") |>
+      dplyr::mutate(v = v * 10) |>
+      replace_table("txn_lazy"),
+    author = "Tester",
+    commit_message = "times ten"
+  ))
+
+  expect_equal(nrow(list_table_snapshots()) - before, 1)
+  expect_equal(sort(dplyr::collect(get_ducklake_table("txn_lazy"))$v), c(10, 20, 30))
+  snapshots <- list_table_snapshots("txn_lazy")
+  expect_equal(snapshots$commit_message[[nrow(snapshots)]], "times ten")
+})
+

--- a/vignettes/clinical-trial-datalake.Rmd
+++ b/vignettes/clinical-trial-datalake.Rmd
@@ -138,9 +138,12 @@ frame. On a lazy lake table it has no effect, because nothing has been read
 into R yet, so we keep the conversion inside DuckDB instead. The helper
 below reads the table's column types from a zero-row query (a lazy table
 cannot inspect its own types) and translates the conversion into SQL that
-runs where the data lives. The pharmaverse test data already stores missing
-values as `NA`, so on these tables the step changes nothing; XPT exports
-read with haven do carry blanks, and there it does.
+runs where the data lives. `create_table()` then runs the whole pipeline
+as `CREATE TABLE ... AS` inside DuckDB and writes the result straight into
+the lake, so a silver table is derived without its rows ever entering R.
+The pharmaverse test data already stores missing values as `NA`, so on
+these tables the conversion changes nothing; XPT exports read with haven do
+carry blanks, and there it does.
 
 ```{r blanks-helper}
 # Convert SDTM blanks to NA inside the database: dbplyr translates na_if()

--- a/vignettes/ducklake.Rmd
+++ b/vignettes/ducklake.Rmd
@@ -164,6 +164,23 @@ with_transaction(
 )
 ```
 
+### Derive a table from another table, inside the database
+
+A pipeline built on `get_ducklake_table()` is written with
+`CREATE TABLE ... AS` in DuckDB: the rows never pass through R, and column
+labels follow the columns into the new table.
+
+```{r derive_in_db}
+with_transaction(
+  get_ducklake_table("cars") |>
+    filter(cyl == 4) |>
+    select(mpg, cyl, hp, wt) |>
+    create_table("small_cars"),
+  author = "Data Analyst",
+  commit_message = "Four-cylinder subset"
+)
+```
+
 ### List all tables in the lake
 
 ```{r list_all_tables}

--- a/vignettes/modifying-tables.Rmd
+++ b/vignettes/modifying-tables.Rmd
@@ -178,8 +178,8 @@ with_transaction(
 )
 ```
 
-`replace_table()` collects the transformed data into R and rewrites the
-table -- the right tool for a bulk rewrite, wasteful for touching three
+`replace_table()` rewrites the whole table inside DuckDB (no rows pass
+through R): the right tool for a bulk rewrite, wasteful for touching three
 rows in a million-row table, and unnecessary for pure schema changes now
 that the in-place functions above exist.
 


### PR DESCRIPTION
Stacked on #50. Base: `review-1-fixes`.

## What changes

`create_table()` and `replace_table()` run dplyr pipelines inside DuckDB. A lazy table on the package connection is written with `CREATE TABLE ... AS`; a replacement is materialized into a temporary DuckDB table first (the query may read the table it replaces) and the table is rebuilt from it with the same drop, create-empty, keys, insert, comment sequence PR #50 introduced. Rows no longer pass through R, so silver and gold layers derived from large bronze tables cost DuckDB memory, not R memory.

Column comments follow the data: each output column keeps the comment of the same-named column in the tables the query reads, so variable labels survive a pipeline as they did through the old collect path. Data frames and lazy tables on other connections load as before.

`restore_table_version()` uses the same rebuild step. The rollback handler is registered ahead of the temp-table cleanup, because DuckDB temp tables are transactional and a rollback after the DROP would bring the copy back.

## Checks

`R CMD check --as-cran` on macOS with duckdb 1.5.5: 0 errors, 0 warnings, the expected note. Tests assert the in-engine path by mocking `dplyr::collect()` to fail.
