### PR TITLE
Back up catalogs without detaching, and add a verbosity option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,21 @@
 # ducklake (development version)
 
+* `backup_ducklake()` copies the catalog with DuckDB's `COPY FROM DATABASE`
+  while the lake stays attached, a consistent snapshot taken inside one
+  transaction, instead of shutting the connection down to release file
+  locks and copying the file. Nothing is detached any more: other attached
+  lakes, in-memory secrets, and a connection registered with
+  `set_ducklake_connection()` (whose locks the old approach could not
+  release, leaving a 0-byte catalog) are left as they are. A SQLite catalog
+  is copied into a SQLite file. Restoring a backup is documented with
+  `create = FALSE`, so a mistyped path is an error rather than a new lake.
+
+* New package option `ducklake.verbose`: set it to `FALSE` to silence the
+  confirmations the package emits after each operation ("Transaction
+  committed.", "Added column ..."). Warnings, errors, and notices about
+  extension downloads stay on. The messages carry the condition class
+  `ducklake_message`.
+
 * Schema-qualified table names work end to end. Every function that takes
   a table name accepts `"schema.table"`: `get_ducklake_table()` hands
   dbplyr a proper table path for it (the duckdb driver's `tbl()` turned a

--- a/R/backup_ducklake.R
+++ b/R/backup_ducklake.R
@@ -1,7 +1,7 @@
 #' Create a DuckLake backup
 #'
 #' Creates a timestamped backup of the Parquet data files and, for file-based
-#' backends (DuckDB, SQLite), the catalog database file. For PostgreSQL/MySQL
+#' backends (DuckDB, SQLite), the catalog database. For PostgreSQL/MySQL
 #' backends only data files are copied; use `pg_dump` / `mysqldump` for the
 #' catalog.
 #'
@@ -16,17 +16,27 @@
 #' @export
 #'
 #' @details
-#' For file-based backends the DuckLake is temporarily detached during backup
-#' to release file locks and ensure a consistent copy. It is automatically
-#' re-attached afterwards.
+#' The catalog is copied with DuckDB's `COPY FROM DATABASE` while the lake
+#' stays attached. The copy is taken inside one transaction, so it is a
+#' consistent snapshot of the metadata, and nothing is detached or shut
+#' down along the way: other attached lakes, in-memory secrets, and a
+#' connection you registered with [set_ducklake_connection()] are left as
+#' they are. The data directories (one per schema) are copied as files.
+#'
+#' To work with the backup, attach it with `lake_path` pointing at the
+#' backup directory. Pass `override_data_path = TRUE`, since the copied
+#' catalog remembers the original data location, and `create = FALSE`, so a
+#' mistyped path is an error rather than a new, empty lake. When the
+#' catalog file was not named after the lake (a split layout), name it with
+#' `catalog_connection_string`.
 #'
 #' **Important notes:**
 #' \itemize{
 #'   \item Transactions committed after a backup won't be tracked when recovering.
 #'     The data will exist in the Parquet files, but the backup will point to
 #'     an earlier snapshot.
-#'   \item Consider coordinating backups with maintenance operations (compaction
-#'     and cleanup) for optimal storage efficiency.
+#'   \item Run compaction and cleanup before a backup, not after: they
+#'     rewrite and remove data files that the copied catalog refers to.
 #'   \item For production systems, schedule backups using \code{{cronR}} or
 #'     \code{{taskscheduleR}}.
 #' }
@@ -44,7 +54,7 @@
 #'   commit_message = "Initial data"
 #' )
 #'
-#' # Create a backup
+#' # Create a backup; the lake stays attached throughout
 #' backup_dir <- backup_ducklake(
 #'   ducklake_name = "my_lake",
 #'   lake_path = lake_dir,
@@ -53,7 +63,8 @@
 #'
 #' # Restore (override_data_path needed when location differs):
 #' # detach_ducklake("my_lake")
-#' # attach_ducklake("my_lake", lake_path = backup_dir, override_data_path = TRUE)
+#' # attach_ducklake("my_lake", lake_path = backup_dir,
+#' #                 override_data_path = TRUE, create = FALSE)
 #'
 #' detach_ducklake("my_lake", shutdown = TRUE)
 #' unlink(lake_dir, recursive = TRUE)
@@ -74,16 +85,17 @@ backup_ducklake <- function(ducklake_name, lake_path, backup_path) {
   }
 
   backend <- get_ducklake_backend(ducklake_name)
+  conn <- get_ducklake_connection()
 
   # Create backup directory with timestamp
   timestamp <- format(Sys.time(), "%Y%m%d_%H%M%S")
   backup_dir <- file.path(backup_path, paste0("backup_", timestamp))
   dir.create(backup_dir, recursive = TRUE, showWarnings = FALSE)
 
-  # File-based backends: shut down to release file locks, copy, re-attach.
-  # Capture the registry's connection string before detaching (which
-  # unregisters the lake); for duckdb it is set when the catalog lives
-  # outside lake_path, and NULL for the default layout.
+  # File-based backends: copy the catalog database through DuckDB, with
+  # the lake still attached. The registry holds the connection string for
+  # a duckdb catalog that lives outside lake_path, NULL for the default
+  # layout.
   if (backend %in% c("duckdb", "sqlite")) {
     stored_catalog <- .ducklake_env$lakes[[ducklake_name]]$catalog_connection_string
     catalog_file <- if (backend == "duckdb" && is.null(stored_catalog)) {
@@ -93,27 +105,11 @@ backup_ducklake <- function(ducklake_name, lake_path, backup_path) {
     }
 
     if (!is.null(catalog_file) && file.exists(catalog_file)) {
-      detach_ducklake(ducklake_name, shutdown = TRUE)
-
-      copy_ok <- file.copy(
-        from = catalog_file,
-        to = file.path(backup_dir, basename(catalog_file))
+      copy_catalog_database(
+        ducklake_name, backend,
+        file.path(backup_dir, basename(catalog_file)), conn
       )
-
-      attach_ducklake(ducklake_name, lake_path = lake_path, backend = backend,
-                      catalog_connection_string = stored_catalog)
-
-      dest_file <- file.path(backup_dir, basename(catalog_file))
-      if (copy_ok && file.size(dest_file) > 0) {
-        cli::cli_inform("Catalog backed up successfully.")
-      } else {
-        cli::cli_warn(c(
-          "Catalog file could not be copied (likely locked by DuckDB).",
-          "i" = "Data files were still backed up."
-        ))
-        # Remove the 0-byte file so it doesn't look like a valid backup
-        unlink(dest_file)
-      }
+      dl_inform("Catalog backed up successfully.")
     } else {
       cli::cli_warn("Catalog file not found: {.path {catalog_file}}")
     }
@@ -142,14 +138,50 @@ backup_ducklake <- function(ducklake_name, lake_path, backup_path) {
   if (length(data_dirs) > 0) {
     for (d in data_dirs) {
       # file.copy(recursive = TRUE) copies `d` *into* backup_dir, preserving
-      # its basename -- same destination fs::dir_copy() targeted.
+      # its basename
       file.copy(from = d, to = backup_dir, recursive = TRUE)
     }
-    cli::cli_inform("Data files backed up successfully ({length(data_dirs)} director{?y/ies}).")
+    dl_inform("Data files backed up successfully ({length(data_dirs)} director{?y/ies}).")
   } else {
     cli::cli_warn("No data directories found in {.path {lake_path}}.")
   }
 
-  cli::cli_inform("Backup completed: {.path {backup_dir}}")
+  dl_inform("Backup completed: {.path {backup_dir}}")
   invisible(backup_dir)
+}
+
+#' Copy a lake's metadata catalog into a new database file
+#'
+#' `COPY FROM DATABASE` reads the attached metadata catalog inside one
+#' transaction, so the copy is consistent, and the lake stays attached: no
+#' file locks to release and no shutdown. A SQLite catalog is copied into a
+#' SQLite file so the backup attaches with the same backend.
+#'
+#' @param ducklake_name The lake whose catalog to copy.
+#' @param backend `"duckdb"` or `"sqlite"`.
+#' @param dest_file Path of the new database file (overwritten).
+#' @param conn A DBI connection.
+#' @returns Invisibly, `dest_file`.
+#' @noRd
+copy_catalog_database <- function(ducklake_name, backend, dest_file, conn) {
+  meta_db <- quote_ident(paste0("__ducklake_metadata_", ducklake_name), conn)
+  alias <- "__ducklake_backup"
+  unlink(dest_file)
+
+  try(db_execute(sprintf("DETACH %s;", alias), conn = conn), silent = TRUE)
+  db_execute(
+    sprintf(
+      "ATTACH %s AS %s%s;",
+      quote_sql(dest_file), alias,
+      if (backend == "sqlite") " (TYPE sqlite)" else ""
+    ),
+    conn = conn
+  )
+  on.exit(
+    try(db_execute(sprintf("DETACH %s;", alias), conn = conn), silent = TRUE),
+    add = TRUE
+  )
+  db_execute(sprintf("COPY FROM DATABASE %s TO %s;", meta_db, alias), conn = conn)
+
+  invisible(dest_file)
 }

--- a/R/comments.R
+++ b/R/comments.R
@@ -38,9 +38,9 @@ set_table_comment <- function(table_name, comment) {
     conn = conn
   )
   if (is_empty_comment(comment)) {
-    cli::cli_inform("Cleared the comment on {.val {table_name}}.")
+    dl_inform("Cleared the comment on {.val {table_name}}.")
   } else {
-    cli::cli_inform("Commented table {.val {table_name}}.")
+    dl_inform("Commented table {.val {table_name}}.")
   }
 
   invisible(NULL)
@@ -133,7 +133,7 @@ set_column_comments <- function(table_name, ...) {
     committed <- TRUE
   }
 
-  cli::cli_inform(
+  dl_inform(
     "Commented {length(statements)} column{?s} on {.val {table_name}}."
   )
 

--- a/R/concurrency.R
+++ b/R/concurrency.R
@@ -70,7 +70,7 @@ set_ducklake_retry <- function(max_retries = NULL, wait_ms = NULL, backoff = NUL
      ORDER BY name"
   )
   value_of <- function(name) settings$value[settings$name == name]
-  cli::cli_inform(
+  dl_inform(
     "DuckLake retries a conflicting transaction up to {value_of('ducklake_max_retry_count')} times, starting {value_of('ducklake_retry_wait_ms')} ms apart with backoff {value_of('ducklake_retry_backoff')}."
   )
 

--- a/R/create_table.R
+++ b/R/create_table.R
@@ -107,7 +107,7 @@ create_table <- function(data_source, table_name, labels = TRUE) {
       committed <- TRUE
     }
     if (length(column_labels) > 0) {
-      cli::cli_inform(
+      dl_inform(
         "Stored {length(column_labels)} column label{?s} as column comment{?s}."
       )
     }
@@ -149,7 +149,7 @@ prepare_data_frame <- function(data, labels = TRUE) {
   factor_cols <- vapply(data, is.factor, logical(1))
   if (any(factor_cols)) {
     data[factor_cols] <- lapply(data[factor_cols], as.character)
-    cli::cli_inform(
+    dl_inform(
       "Converted factor column{?s} {.field {names(data)[factor_cols]}} to character (DuckLake does not support ENUM columns)."
     )
   }
@@ -259,7 +259,7 @@ create_table_from_query <- function(.data, table_name, labels, conn) {
     committed <- TRUE
   }
   if (length(column_comments) > 0) {
-    cli::cli_inform(
+    dl_inform(
       "Stored {length(column_comments)} column label{?s} as column comment{?s}."
     )
   }

--- a/R/data_files.R
+++ b/R/data_files.R
@@ -157,7 +157,7 @@ add_data_files <- function(table_name,
     committed <- TRUE
   }
 
-  cli::cli_inform(c(
+  dl_inform(c(
     "Added {length(files)} file{?s} to table {.val {table_name}}.",
     # Inside a caller's transaction the snapshot is theirs and not yet
     # committed, so only claim atomicity for a batch this call committed.

--- a/R/data_inlining.R
+++ b/R/data_inlining.R
@@ -81,7 +81,7 @@ set_inlining_row_limit <- function(limit,
       conn,
       sprintf("SET ducklake_default_data_inlining_row_limit = %d;", limit)
     )
-    cli::cli_inform(
+    dl_inform(
       "Global data inlining row limit set to {.val {limit}}."
     )
   } else {
@@ -112,7 +112,7 @@ set_inlining_row_limit <- function(limit,
     } else {
       paste0("schema {.val ", schema_name, "}")
     }
-    cli::cli_inform(
+    dl_inform(
       "Data inlining row limit for {scope} set to {.val {limit}}."
     )
   }
@@ -323,11 +323,11 @@ flush_inlined_data <- function(ducklake_name = NULL,
   if (nrow(result) > 0L) {
     total <- sum(result$rows_flushed)
     n_tables <- nrow(result)
-    cli::cli_inform(
+    dl_inform(
       "Flushed {.val {total}} row{?s} from {.val {n_tables}} table{?s} to Parquet."
     )
   } else {
-    cli::cli_inform("No inlined data to flush.")
+    dl_inform("No inlined data to flush.")
   }
 
   result
@@ -407,7 +407,7 @@ checkpoint_ducklake <- function(ducklake_name = NULL) {
   check_identifier(ducklake_name)
 
   DBI::dbExecute(conn, sprintf("CHECKPOINT %s;", ducklake_name))
-  cli::cli_inform("Checkpoint completed for {.val {ducklake_name}}.")
+  dl_inform("Checkpoint completed for {.val {ducklake_name}}.")
 
   invisible(NULL)
 }

--- a/R/ducklake-package.R
+++ b/R/ducklake-package.R
@@ -1,3 +1,13 @@
+#' @section Package options:
+#' \describe{
+#'   \item{`ducklake.verbose`}{When `FALSE`, the confirmations the package
+#'     emits after each operation ("Transaction committed.", "Added column
+#'     ...") are suppressed, which keeps pipeline logs quiet. Warnings,
+#'     errors, and notices about extension downloads are unaffected. The
+#'     messages carry the condition class `ducklake_message`. Default
+#'     `TRUE`.}
+#' }
+#'
 #' @keywords internal
 "_PACKAGE"
 

--- a/R/maintenance.R
+++ b/R/maintenance.R
@@ -96,14 +96,14 @@ expire_snapshots <- function(ducklake_name = NULL,
 
   n <- nrow(result)
   if (isTRUE(dry_run)) {
-    cli::cli_inform("Dry run: {.val {n}} snapshot{?s} would be expired.")
+    dl_inform("Dry run: {.val {n}} snapshot{?s} would be expired.")
   } else if (n > 0) {
-    cli::cli_inform(c(
+    dl_inform(c(
       "Expired {.val {n}} snapshot{?s}.",
       "i" = "Unreferenced files are scheduled for deletion; run {.fun cleanup_old_files} to reclaim storage."
     ))
   } else {
-    cli::cli_inform("No snapshots to expire.")
+    dl_inform("No snapshots to expire.")
   }
 
   result
@@ -203,11 +203,11 @@ merge_adjacent_files <- function(ducklake_name = NULL,
 
   if (nrow(result) > 0) {
     merged <- sum(result$files_processed)
-    cli::cli_inform(
+    dl_inform(
       "Merged {.val {merged}} file{?s} into {.val {nrow(result)}} file{?s}."
     )
   } else {
-    cli::cli_inform("No adjacent files to merge.")
+    dl_inform("No adjacent files to merge.")
   }
 
   result
@@ -256,9 +256,9 @@ run_file_cleanup <- function(sql_function, what,
 
   n <- nrow(result)
   if (isTRUE(dry_run)) {
-    cli::cli_inform("Dry run: {.val {n}} {cli::qty(n)}{what}{?s} would be deleted.")
+    dl_inform("Dry run: {.val {n}} {cli::qty(n)}{what}{?s} would be deleted.")
   } else {
-    cli::cli_inform("Deleted {.val {n}} {cli::qty(n)}{what}{?s}.")
+    dl_inform("Deleted {.val {n}} {cli::qty(n)}{what}{?s}.")
   }
 
   result
@@ -457,11 +457,11 @@ rewrite_data_files <- function(ducklake_name = NULL,
 
   if (nrow(result) > 0) {
     rewritten <- sum(result$files_processed)
-    cli::cli_inform(
+    dl_inform(
       "Rewrote {.val {rewritten}} file{?s} into {.val {nrow(result)}} file{?s}."
     )
   } else {
-    cli::cli_inform("No files needed rewriting.")
+    dl_inform("No files needed rewriting.")
   }
 
   result

--- a/R/merge_into.R
+++ b/R/merge_into.R
@@ -275,7 +275,7 @@ merge_into <- function(target, source, by,
   }
 
   if (!.quiet) {
-    cli::cli_inform(
+    dl_inform(
       "Merged {.arg source} into {.val {target_name}}: {n} row{?s} affected."
     )
   }

--- a/R/options.R
+++ b/R/options.R
@@ -87,7 +87,7 @@ set_ducklake_option <- function(option,
   } else {
     "lake {.val {ducklake_name}}"
   }
-  cli::cli_inform(paste0(
+  dl_inform(paste0(
     "Option {.val {option}} set to {.val {value}} for ", scope, "."
   ))
 

--- a/R/partitioning.R
+++ b/R/partitioning.R
@@ -83,7 +83,7 @@ set_table_partitioning <- function(table_name, partition_by) {
     ),
     conn = conn
   )
-  cli::cli_inform(c(
+  dl_inform(c(
     "Table {.val {table_name}} is now partitioned by {.val {partition_by}}.",
     "i" = "Only newly written data is partitioned; existing files keep their layout."
   ))
@@ -125,7 +125,7 @@ reset_table_partitioning <- function(table_name) {
     ),
     conn = conn
   )
-  cli::cli_inform("Partitioning removed from table {.val {table_name}}.")
+  dl_inform("Partitioning removed from table {.val {table_name}}.")
 
   invisible(NULL)
 }

--- a/R/quack.R
+++ b/R/quack.R
@@ -30,11 +30,11 @@ install_quack <- function(load = TRUE) {
   check_quack_version()
 
   db_execute("INSTALL quack;")
-  cli::cli_inform("Installed {.pkg quack} extension.")
+  dl_inform("Installed {.pkg quack} extension.")
 
   if (load) {
     db_execute("LOAD quack;")
-    cli::cli_inform("Loaded {.pkg quack} extension.")
+    dl_inform("Loaded {.pkg quack} extension.")
   }
 
   invisible(NULL)
@@ -253,7 +253,7 @@ quack_serve <- function(uri = "quack:localhost", token = NULL,
   }
 
   db_execute(sprintf("CALL quack_serve(%s);", paste(args, collapse = ", ")))
-  cli::cli_inform("Quack server listening on {.val {uri}}.")
+  dl_inform("Quack server listening on {.val {uri}}.")
 
   invisible(uri)
 }
@@ -280,7 +280,7 @@ quack_stop <- function(uri = "quack:localhost") {
   ensure_quack_extension()
 
   db_execute(sprintf("CALL quack_stop(%s);", quote_sql(uri)))
-  cli::cli_inform("Quack server on {.val {uri}} stopped.")
+  dl_inform("Quack server on {.val {uri}} stopped.")
 
   invisible(TRUE)
 }

--- a/R/replace_table.R
+++ b/R/replace_table.R
@@ -96,7 +96,7 @@
 replace_table <- function(.data, table_name, .quiet = TRUE) {
 
   if (!.quiet) {
-    cli::cli_inform("Replacing table {.val {table_name}}...")
+    dl_inform("Replacing table {.val {table_name}}...")
   }
 
   conn <- get_ducklake_connection()
@@ -129,7 +129,7 @@ replace_table <- function(.data, table_name, .quiet = TRUE) {
 
   if (!.quiet) {
     n <- DBI::dbGetQuery(conn, sprintf("SELECT count(*) AS n FROM %s", source_ref))$n
-    cli::cli_inform("Prepared {n} row{?s} for {.val {table_name}}.")
+    dl_inform("Prepared {n} row{?s} for {.val {table_name}}.")
   }
 
   # The drop and create must land together: outside a transaction they
@@ -162,7 +162,7 @@ replace_table <- function(.data, table_name, .quiet = TRUE) {
   reapply_table_options(meta, conn)
 
   if (!.quiet) {
-    cli::cli_inform("Table {.val {table_name}} successfully replaced.")
+    dl_inform("Table {.val {table_name}} successfully replaced.")
   }
 
   invisible(NULL)

--- a/R/rows_operations.R
+++ b/R/rows_operations.R
@@ -347,7 +347,7 @@ rows_upsert.tbl_ducklake <- function(x, y, by = NULL, ...,
 
   if (is.null(by)) {
     by <- y_cols[[1]]
-    cli::cli_inform('Matching, by = "{by}"')
+    dl_inform('Matching, by = "{by}"')
   }
   if (!is.character(by) || length(by) == 0 || anyNA(by)) {
     cli::cli_abort("{.arg by} must be a character vector of column names.")

--- a/R/schema_evolution.R
+++ b/R/schema_evolution.R
@@ -53,7 +53,7 @@ add_table_column <- function(table_name, column_name, type, default = NULL) {
     ),
     conn = conn
   )
-  cli::cli_inform(c(
+  dl_inform(c(
     "Added column {.val {column_name}} ({type}) to {.val {table_name}}.",
     "i" = "Metadata-only change; no data files were rewritten."
   ))
@@ -100,7 +100,7 @@ drop_table_column <- function(table_name, column_name) {
     ),
     conn = conn
   )
-  cli::cli_inform(
+  dl_inform(
     "Dropped column {.val {column_name}} from {.val {table_name}}. Earlier snapshots still contain it."
   )
 
@@ -145,7 +145,7 @@ rename_table_column <- function(table_name, from, to) {
     ),
     conn = conn
   )
-  cli::cli_inform(
+  dl_inform(
     "Renamed column {.val {from}} to {.val {to}} in {.val {table_name}}."
   )
 
@@ -193,7 +193,7 @@ rename_ducklake_table <- function(from, to) {
     ),
     conn = conn
   )
-  cli::cli_inform(c(
+  dl_inform(c(
     "Renamed table {.val {from}} to {.val {to}}.",
     "i" = "Snapshots from before the rename remain queryable under the old name."
   ))
@@ -264,7 +264,7 @@ set_column_type <- function(table_name, column_name, type) {
       stop(e)
     }
   )
-  cli::cli_inform(
+  dl_inform(
     "Column {.val {column_name}} in {.val {table_name}} is now {type}."
   )
 

--- a/R/schemas.R
+++ b/R/schemas.R
@@ -46,7 +46,7 @@ create_schema <- function(schema_name, if_not_exists = TRUE, ducklake_name = NUL
     if (!if_not_exists) {
       cli::cli_abort("Schema {.val {schema_name}} already exists in {.val {ducklake_name}}.")
     }
-    cli::cli_inform("Schema {.val {schema_name}} already exists.")
+    dl_inform("Schema {.val {schema_name}} already exists.")
     return(invisible(NULL))
   }
 
@@ -54,7 +54,7 @@ create_schema <- function(schema_name, if_not_exists = TRUE, ducklake_name = NUL
     sprintf("CREATE SCHEMA %s.%s;", quote_ident(ducklake_name, conn), quoted),
     conn = conn
   )
-  cli::cli_inform("Created schema {.val {schema_name}}.")
+  dl_inform("Created schema {.val {schema_name}}.")
 
   invisible(NULL)
 }
@@ -102,7 +102,7 @@ drop_schema <- function(schema_name, cascade = FALSE, ducklake_name = NULL) {
     ),
     conn = conn
   )
-  cli::cli_inform("Dropped schema {.val {schema_name}}.")
+  dl_inform("Dropped schema {.val {schema_name}}.")
 
   invisible(NULL)
 }

--- a/R/sorting.R
+++ b/R/sorting.R
@@ -77,7 +77,7 @@ set_table_sorting <- function(table_name, sort_by) {
     ),
     conn = conn
   )
-  cli::cli_inform(c(
+  dl_inform(c(
     "Table {.val {table_name}} is now sorted by {.val {sort_by}}.",
     "i" = "Only newly written data is sorted; existing files keep their layout until compaction."
   ))
@@ -119,7 +119,7 @@ reset_table_sorting <- function(table_name) {
     ),
     conn = conn
   )
-  cli::cli_inform("Sort order removed from table {.val {table_name}}.")
+  dl_inform("Sort order removed from table {.val {table_name}}.")
 
   invisible(NULL)
 }

--- a/R/storage_secrets.R
+++ b/R/storage_secrets.R
@@ -135,7 +135,7 @@ create_storage_secret <- function(type = c("s3", "gcs", "r2", "azure"),
   )
   db_execute(sql, conn = conn)
 
-  cli::cli_inform(
+  dl_inform(
     "Created {if (persistent) 'persistent ' else ''}{.val {type}} storage secret{if (!is.null(name)) ' {.val {name}}' else ''}."
   )
 

--- a/R/time_travel.R
+++ b/R/time_travel.R
@@ -361,7 +361,7 @@ restore_table_version <- function(table_name, version = NULL, timestamp = NULL,
       conn = conn
     )
     reapply_table_options(meta, conn)
-    cli::cli_inform("Table {.val {table_name}} restored to {restore_point} (recorded as a new snapshot).")
+    dl_inform("Table {.val {table_name}} restored to {restore_point} (recorded as a new snapshot).")
     invisible(TRUE)
   }, error = function(e) {
     cli::cli_abort(c(

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -45,7 +45,7 @@ begin_transaction <- function(conn = NULL) {
   }
 
   DBI::dbExecute(conn, "BEGIN TRANSACTION;")
-  cli::cli_inform("Transaction started.")
+  dl_inform("Transaction started.")
   invisible(TRUE)
 }
 
@@ -155,7 +155,7 @@ commit_transaction <- function(
   }
 
   DBI::dbExecute(conn, "COMMIT;")
-  cli::cli_inform("Transaction committed.")
+  dl_inform("Transaction committed.")
 
   invisible(TRUE)
 }
@@ -279,7 +279,7 @@ set_snapshot_metadata <- function(
   tryCatch(
     {
       DBI::dbExecute(conn, update_sql, params = unname(provided))
-      cli::cli_inform("Snapshot metadata updated.")
+      dl_inform("Snapshot metadata updated.")
       invisible(TRUE)
     },
     error = function(e) {
@@ -433,6 +433,6 @@ rollback_transaction <- function(conn = NULL) {
   }
 
   DBI::dbExecute(conn, "ROLLBACK;")
-  cli::cli_inform("Transaction rolled back.")
+  dl_inform("Transaction rolled back.")
   invisible(TRUE)
 }

--- a/R/update_table.R
+++ b/R/update_table.R
@@ -67,7 +67,7 @@
 update_table <- function(.data, table_name, .quiet = FALSE, .execute = TRUE) {
 
   if (!.quiet) {
-    cli::cli_inform("Translating dplyr query into an in-place statement for {.val {table_name}}.")
+    dl_inform("Translating dplyr query into an in-place statement for {.val {table_name}}.")
   }
 
   result_sql <- tryCatch(
@@ -82,7 +82,7 @@ update_table <- function(.data, table_name, .quiet = FALSE, .execute = TRUE) {
     }
   )
 
-  if (!.quiet) cli::cli_inform("Generated SQL: {.code {result_sql}}")
+  if (!.quiet) dl_inform("Generated SQL: {.code {result_sql}}")
 
   if (.execute) {
     db_execute(result_sql)
@@ -212,7 +212,7 @@ build_in_place_sql <- function(.data, table_name, .quiet = FALSE) {
           call = NULL
         )
       }
-      if (!.quiet) cli::cli_inform("Operation type: {.val update}")
+      if (!.quiet) dl_inform("Operation type: {.val update}")
       assignments <- paste0(
         quoted_names[is_assignment], " = ", entry_exprs[is_assignment],
         collapse = ", "
@@ -225,7 +225,7 @@ build_in_place_sql <- function(.data, table_name, .quiet = FALSE) {
     }
 
     # filter() only: keep the matching rows, delete the rest
-    if (!.quiet) cli::cli_inform("Operation type: {.val delete}")
+    if (!.quiet) dl_inform("Operation type: {.val delete}")
     return(sprintf("DELETE FROM %s WHERE NOT (%s)", quoted_table, where_sql))
   }
 
@@ -254,7 +254,7 @@ build_in_place_sql <- function(.data, table_name, .quiet = FALSE) {
     )
   }
 
-  if (!.quiet) cli::cli_inform("Operation type: {.val insert}")
+  if (!.quiet) dl_inform("Operation type: {.val insert}")
   insert_cols <- vapply(
     colnames(.data),
     function(nm) as.character(DBI::dbQuoteIdentifier(con, nm)),

--- a/R/utils.R
+++ b/R/utils.R
@@ -399,3 +399,23 @@ table_filter <- function(table_name, table_col = "t.table_name") {
     )
   }
 }
+
+#' Emit a routine confirmation, unless the session turned them off
+#'
+#' Every operation confirms what it did through this wrapper, so a
+#' pipeline can silence the chatter with `options(ducklake.verbose =
+#' FALSE)`. Warnings, errors, and notices about extension downloads are
+#' emitted directly and stay on. Messages carry the class
+#' `ducklake_message` for handlers that want to route them.
+#'
+#' @param message,... Passed to [cli::cli_inform()].
+#' @param .envir Environment for glue interpolation; the caller's frame.
+#' @returns Invisibly, `NULL`.
+#' @noRd
+dl_inform <- function(message, ..., .envir = parent.frame()) {
+  if (!isTRUE(getOption("ducklake.verbose", TRUE))) {
+    return(invisible(NULL))
+  }
+  cli::cli_inform(message, ..., class = "ducklake_message", .envir = .envir)
+  invisible(NULL)
+}

--- a/R/views.R
+++ b/R/views.R
@@ -60,7 +60,7 @@ create_view <- function(.data, view_name, replace = TRUE) {
     ),
     conn = conn
   )
-  cli::cli_inform("Created view {.val {view_name}}.")
+  dl_inform("Created view {.val {view_name}}.")
 
   invisible(NULL)
 }
@@ -99,7 +99,7 @@ drop_view <- function(view_name) {
     sprintf("DROP VIEW %s;", quote_ident(view_name, conn)),
     conn = conn
   )
-  cli::cli_inform("Dropped view {.val {view_name}}.")
+  dl_inform("Dropped view {.val {view_name}}.")
 
   invisible(NULL)
 }

--- a/man/backup_ducklake.Rd
+++ b/man/backup_ducklake.Rd
@@ -20,22 +20,32 @@ Invisibly returns the path to the created backup directory
 }
 \description{
 Creates a timestamped backup of the Parquet data files and, for file-based
-backends (DuckDB, SQLite), the catalog database file. For PostgreSQL/MySQL
+backends (DuckDB, SQLite), the catalog database. For PostgreSQL/MySQL
 backends only data files are copied; use \code{pg_dump} / \code{mysqldump} for the
 catalog.
 }
 \details{
-For file-based backends the DuckLake is temporarily detached during backup
-to release file locks and ensure a consistent copy. It is automatically
-re-attached afterwards.
+The catalog is copied with DuckDB's \verb{COPY FROM DATABASE} while the lake
+stays attached. The copy is taken inside one transaction, so it is a
+consistent snapshot of the metadata, and nothing is detached or shut
+down along the way: other attached lakes, in-memory secrets, and a
+connection you registered with \code{\link[=set_ducklake_connection]{set_ducklake_connection()}} are left as
+they are. The data directories (one per schema) are copied as files.
+
+To work with the backup, attach it with \code{lake_path} pointing at the
+backup directory. Pass \code{override_data_path = TRUE}, since the copied
+catalog remembers the original data location, and \code{create = FALSE}, so a
+mistyped path is an error rather than a new, empty lake. When the
+catalog file was not named after the lake (a split layout), name it with
+\code{catalog_connection_string}.
 
 \strong{Important notes:}
 \itemize{
 \item Transactions committed after a backup won't be tracked when recovering.
 The data will exist in the Parquet files, but the backup will point to
 an earlier snapshot.
-\item Consider coordinating backups with maintenance operations (compaction
-and cleanup) for optimal storage efficiency.
+\item Run compaction and cleanup before a backup, not after: they
+rewrite and remove data files that the copied catalog refers to.
 \item For production systems, schedule backups using \code{{cronR}} or
 \code{{taskscheduleR}}.
 }
@@ -54,7 +64,7 @@ with_transaction(
   commit_message = "Initial data"
 )
 
-# Create a backup
+# Create a backup; the lake stays attached throughout
 backup_dir <- backup_ducklake(
   ducklake_name = "my_lake",
   lake_path = lake_dir,
@@ -63,7 +73,8 @@ backup_dir <- backup_ducklake(
 
 # Restore (override_data_path needed when location differs):
 # detach_ducklake("my_lake")
-# attach_ducklake("my_lake", lake_path = backup_dir, override_data_path = TRUE)
+# attach_ducklake("my_lake", lake_path = backup_dir,
+#                 override_data_path = TRUE, create = FALSE)
 
 detach_ducklake("my_lake", shutdown = TRUE)
 unlink(lake_dir, recursive = TRUE)

--- a/man/ducklake-package.Rd
+++ b/man/ducklake-package.Rd
@@ -10,6 +10,18 @@
 
 A 'tidyverse'-friendly interface to 'DuckLake' \url{https://ducklake.select/}, the 'DuckDB' lakehouse format. Attach versioned data lakes from R and work with them using familiar 'dplyr' verbs, with support for ACID transactions, time travel queries, snapshot audit trails, data inlining, encrypted storage, multiple catalog backends ('DuckDB', 'PostgreSQL', 'SQLite', 'MySQL'), and remote access over the 'Quack' protocol from 'DuckDB'.
 }
+\section{Package options}{
+
+\describe{
+\item{\code{ducklake.verbose}}{When \code{FALSE}, the confirmations the package
+emits after each operation ("Transaction committed.", "Added column
+...") are suppressed, which keeps pipeline logs quiet. Warnings,
+errors, and notices about extension downloads are unaffected. The
+messages carry the condition class \code{ducklake_message}. Default
+\code{TRUE}.}
+}
+}
+
 \seealso{
 Useful links:
 \itemize{

--- a/tests/testthat/test-hardening.R
+++ b/tests/testthat/test-hardening.R
@@ -394,3 +394,29 @@ test_that("create_table converts factor columns instead of failing on ENUM", {
   expect_equal(nrow(result), 150)
   expect_type(result$Species, "character")
 })
+
+test_that("options(ducklake.verbose = FALSE) silences routine confirmations", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  old <- options(ducklake.verbose = FALSE)
+  on.exit(options(old), add = TRUE)
+
+  expect_silent(create_table(data.frame(id = 1:3), "quiet_t"))
+  expect_silent(add_table_column("quiet_t", "flag", "BOOLEAN"))
+  expect_silent(with_transaction(
+    rows_insert(get_ducklake_table("quiet_t"), data.frame(id = 4L), by = "id"),
+    author = "Tester", commit_message = "quiet"
+  ))
+  expect_equal(nrow(dplyr::collect(get_ducklake_table("quiet_t"))), 4)
+
+  # Warnings and errors are not affected
+  expect_error(add_table_column("quiet_t", "id", "INTEGER"))
+
+  options(ducklake.verbose = TRUE)
+  expect_message(drop_table_column("quiet_t", "flag"), "Dropped column")
+})
+

--- a/tests/testthat/test-maintenance.R
+++ b/tests/testthat/test-maintenance.R
@@ -214,3 +214,46 @@ test_that("checkpoint expires snapshots only under a retention policy", {
   })
   expect_false(first_id %in% list_table_snapshots()$snapshot_id)
 })
+
+test_that("backup_ducklake() keeps every lake attached and copies a consistent catalog", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+  other_dir <- tempfile("other_lake_")
+  dir.create(other_dir)
+  on.exit(unlink(other_dir, recursive = TRUE), add = TRUE)
+  backup_root <- tempfile("backup_root_")
+  on.exit(unlink(backup_root, recursive = TRUE), add = TRUE)
+
+  create_table(mtcars, "cars")
+  attach_ducklake("other_lake", lake_path = other_dir)
+  create_table(iris[1:5, 1:4], "flowers")
+  on.exit(detach_ducklake("other_lake"), add = TRUE)
+  conn <- get_ducklake_connection()
+  DBI::dbExecute(conn, sprintf("USE %s;", lake$ducklake_name))
+
+  backup_dir <- suppressMessages(
+    backup_ducklake(lake$ducklake_name, lake_path = lake$lake_path, backup_path = backup_root)
+  )
+
+  # Nothing was detached or shut down
+  attached <- DBI::dbGetQuery(conn, "SELECT database_name FROM duckdb_databases()")$database_name
+  expect_true(all(c(lake$ducklake_name, "other_lake") %in% attached))
+  expect_identical(get_ducklake_connection(), conn)
+  expect_equal(nrow(dplyr::collect(get_ducklake_table("cars"))), 32)
+
+  # A write after the backup is not in the copy
+  suppressMessages(rows_insert(get_ducklake_table("cars"), data.frame(mpg = 1), by = "mpg"))
+  catalog_copy <- file.path(backup_dir, paste0(lake$ducklake_name, ".ducklake"))
+  expect_true(file.size(catalog_copy) > 0)
+  attach_ducklake(
+    "restored_lake", lake_path = backup_dir,
+    catalog_connection_string = catalog_copy,
+    override_data_path = TRUE, create = FALSE
+  )
+  on.exit(detach_ducklake("restored_lake"), add = TRUE)
+  expect_equal(nrow(dplyr::collect(get_ducklake_table("cars"))), 32)
+})
+

--- a/tests/testthat/test-multi-backend.R
+++ b/tests/testthat/test-multi-backend.R
@@ -314,6 +314,25 @@ test_that("SQLite backend: create table, query, and time travel", {
         dplyr::collect()
       expect_false("kpl" %in% names(v1))
 
+      # The catalog backs up as a SQLite file and attaches again
+      backup_root <- file.path(temp_dir, "backups")
+      backup_dir <- suppressMessages(
+        backup_ducklake("test_sqlite_backend", lake_path = sqlite_data, backup_path = backup_root)
+      )
+      backup_catalog <- file.path(backup_dir, "metadata.sqlite")
+      expect_true(file.size(backup_catalog) > 0)
+      attach_ducklake(
+        "sqlite_restored",
+        backend = "sqlite",
+        catalog_connection_string = backup_catalog,
+        lake_path = backup_dir,
+        override_data_path = TRUE,
+        create = FALSE
+      )
+      expect_equal(nrow(dplyr::collect(get_ducklake_table("cars"))), 32)
+      detach_ducklake("sqlite_restored")
+      DBI::dbExecute(get_ducklake_connection(), "USE test_sqlite_backend;")
+
       # Full shutdown to release all resources
       detach_ducklake("test_sqlite_backend", shutdown = TRUE)
     },

--- a/vignettes/storage-and-backups.Rmd
+++ b/vignettes/storage-and-backups.Rmd
@@ -228,28 +228,26 @@ The key insight is that **DuckLake never modifies existing Parquet files**. Each
 
 The catalog is the most critical component—it maps snapshots to data files. Regular backups are essential.
 
-#### Simple File Copy
+#### Copying the Catalog
 
-For local databases, the simplest backup is a file copy. One rule matters:
-**release the file locks first**. DuckDB holds the catalog file open while a
-lake is attached, and copying a live catalog produces a corrupt (or, on
-Windows, unreadable) backup. Detach with `shutdown = TRUE`, copy, then
-re-attach — or skip the manual steps entirely and use `backup_ducklake()`,
-which does exactly this dance for you:
+`backup_ducklake()` copies the catalog with DuckDB's `COPY FROM DATABASE`
+while the lake stays attached. The copy is taken inside one transaction,
+so it is a consistent snapshot of the metadata, and nothing is detached or
+shut down along the way. The same statement works by hand:
 
 ```{r backup-catalog-simple}
 # Create backup directory
 backup_dir <- file.path(lake_dir, "backups")
 dir.create(backup_dir, showWarnings = FALSE)
 
-# Release file locks before copying the catalog
-detach_ducklake("demo_lake", shutdown = TRUE)
-
-# Copy the catalog file to create a backup
-file.copy(
-  from = file.path(lake_dir, "demo_lake.ducklake"),
-  to = file.path(backup_dir, "demo_lake.ducklake")
-)
+# Copy the catalog through DuckDB: the metadata catalog of an attached lake
+# is the database __ducklake_metadata_<name>
+conn <- get_ducklake_connection()
+DBI::dbExecute(conn, sprintf(
+  "ATTACH '%s' AS backup;", file.path(backup_dir, "demo_lake.ducklake")
+))
+DBI::dbExecute(conn, "COPY FROM DATABASE __ducklake_metadata_demo_lake TO backup;")
+DBI::dbExecute(conn, "DETACH backup;")
 
 # Copy the data directory as well
 dir_copy(
@@ -259,14 +257,25 @@ dir_copy(
 
 # Verify the backup was created
 dir_tree(backup_dir)
+```
 
-# To work with the backup, attach it. override_data_path is needed because
-# the catalog remembers the original data location, which the backup no
-# longer matches.
+A plain file copy of the `.ducklake` file works too, but only after
+releasing DuckDB's lock on it: detach with `shutdown = TRUE`, copy, then
+re-attach. Copying a live catalog produces a corrupt (or, on Windows,
+unreadable) file.
+
+To work with the backup, attach it. `override_data_path` is needed because
+the catalog remembers the original data location, which the backup no
+longer matches, and `create = FALSE` turns a mistyped path into an error
+instead of a new, empty lake:
+
+```{r attach-backup}
+detach_ducklake("demo_lake")
 attach_ducklake(
   ducklake_name = "demo_lake",
   lake_path = backup_dir,
-  override_data_path = TRUE
+  override_data_path = TRUE,
+  create = FALSE
 )
 
 # Verify you're working with the backup
@@ -346,8 +355,9 @@ file.copy(
   overwrite = TRUE
 )
 
-# Reattach to the restored database
-attach_ducklake("demo_lake", lake_path = lake_dir)
+# Reattach to the restored database (detach with shutdown = TRUE before
+# overwriting the file, so DuckDB is not holding it open)
+attach_ducklake("demo_lake", lake_path = lake_dir, create = FALSE)
 
 # Verify recovery by listing snapshots
 list_table_snapshots("cars")
@@ -441,25 +451,13 @@ cleanup_old_files(cleanup_all = TRUE)
 # 2. Ensure all transactions are committed
 # (no pending work)
 
-# 3. Release file locks before copying the catalog
-detach_ducklake("demo_lake", shutdown = TRUE)
-
-# 4. Back up catalog
-dir.create(file.path(lake_dir, "backups"), showWarnings = FALSE)
-file.copy(
-  from = file.path(lake_dir, "demo_lake.ducklake"),
-  to = file.path(lake_dir, "backups",
-                 paste0("backup_", format(Sys.time(), "%Y%m%d_%H%M%S"), ".ducklake"))
+# 3. Back up: the catalog through COPY FROM DATABASE, the data files by
+#    copy, with the lake still attached
+backup_ducklake(
+  "demo_lake",
+  lake_path = lake_dir,
+  backup_path = file.path(lake_dir, "backups")
 )
-
-# 5. Back up data files
-dir_copy(
-  path = file.path(lake_dir, "main"),
-  new_path = file.path(lake_dir, "backups", "main_latest")
-)
-
-# 6. Re-attach and continue working
-attach_ducklake("demo_lake", lake_path = lake_dir)
 ```
 
 ## Complete Backup Example
@@ -480,7 +478,7 @@ print(backup_dir)
 
 The `backup_ducklake()` function:
 - Creates a timestamped backup directory
-- Copies the catalog database file (releasing file locks first)
+- Copies the catalog through `COPY FROM DATABASE`, with the lake still attached
 - Copies the data files from every schema directory in the lake
 - Returns the backup directory path for reference
 


### PR DESCRIPTION
Stacked on #52. Base: `review-3-schemas-attach`.

## What changes

- `backup_ducklake()` copies the catalog with DuckDB's `COPY FROM DATABASE` while the lake stays attached. The copy is taken inside one transaction, so it is a consistent snapshot of the metadata, and nothing is detached or shut down: other attached lakes, in-memory secrets, and a connection registered with `set_ducklake_connection()` (whose locks the old shutdown approach could not release, leaving a 0-byte catalog) are untouched. SQLite catalogs are copied into a SQLite file. The storage vignette shows the statement by hand and the restore with `create = FALSE`.
- New option `ducklake.verbose`: routine confirmations go through one wrapper and can be silenced for pipeline logs. Warnings, errors, and notices about extension downloads stay on.

## Checks

`R CMD check --as-cran` on macOS with duckdb 1.5.5: 0 errors, 0 warnings, the expected note. Tests cover a backup taken with two lakes attached (both stay attached; a write after the backup is not in the copy) and a SQLite catalog backup that attaches again.
