### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ducklake
 Title: Interact with 'DuckLake' from R
-Version: 0.6.0.9000
+Version: 0.7.0
 Authors@R: c(
     person("Travis", "Gerke", , "travisgerke@gmail.com", role = c("aut", "cre")),
     person("Stefan", "Linner", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ducklake (development version)
+# ducklake 0.7.0
 
 * New article "Choosing a Deployment" (`vignette("deployment")`): what a
   lake looks like on disk, which catalog backend fits one person, a team on


### PR DESCRIPTION
Closes out the development version after the review series (#50 to #54): DESCRIPTION goes to 0.7.0 and the NEWS heading is dated to the release. No code changes.