### PR TITLE
Rewrite Getting Started and confirm commits with one line

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@
 - **SQL macros are deliberately not wrapped** (2026-08-10). A macro body is
   raw SQL, and dbplyr cannot translate R calls into user-defined macros, so
   a wrapper would add quoting risk without removing any SQL from user code.
-  Views (`create_view()`) cover shared logic; the cookbook vignette
+  Views (`create_view()`) cover shared logic; `vignette("views-comments-labels")`
   documents the raw `DBI::dbExecute()` escape hatch for macros.
 
 ## Reference
@@ -73,6 +73,21 @@
   `DUCKDB_R_HOME`.
 - **Iceberg interop is documented, not wrapped** (2026-09-04): `COPY FROM
   DATABASE lake TO iceberg_catalog` and `iceberg_to_ducklake()` live in
-  DuckDB's iceberg extension; the cookbook shows them. This closes the
+  DuckDB's iceberg extension; `vignette("loading-data")` shows them. This closes the
   "one-command Iceberg catalog export" watch item above.
-
+- **A commit is confirmed with one line naming its snapshot** (2026-09-06).
+  `begin_transaction()` is silent and stashes the lake's current snapshot
+  id; `commit_transaction()` reads it again after `COMMIT` and prints
+  `Committed snapshot N (author): message`, or says nothing changed when
+  the id did not move. DuckLake assigns the id only at commit, and an
+  empty or read-only transaction creates no snapshot (confirmed on the
+  DuckDB and SQLite catalogs). Limitation: DuckLake has no query for "the
+  snapshot this transaction created", so the id is whatever
+  `current_snapshot()` returns right after the commit; with concurrent
+  writers it can belong to a neighbor's commit that landed in between.
+  Functions that commit for themselves (`restore_table_version()`) print
+  no second confirmation.
+- **Article layout** (2026-09-06): `vignette("ducklake")` (Getting
+  Started) is one short linear session; recipes live in topical articles
+  (Loading Data; Views, Comments, and Labels; Modifying Tables; Choosing a
+  Deployment). New recipes go to those, not to Getting Started.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ducklake
 Title: Interact with 'DuckLake' from R
-Version: 0.7.0
+Version: 0.7.0.9000
 Authors@R: c(
     person("Travis", "Gerke", , "travisgerke@gmail.com", role = c("aut", "cre")),
     person("Stefan", "Linner", role = "ctb"),
@@ -34,6 +34,7 @@ Suggests:
     ggplot2,
     jsonlite,
     knitr,
+    labelled,
     lubridate,
     pharmaversesdtm,
     purrr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # ducklake (development version)
 
+* `with_transaction()` and `commit_transaction()` confirm a commit with one
+  line naming the snapshot it created, with the author and commit message
+  when they were given: "Committed snapshot 3 (Data Engineer): Add the
+  Motor Trend car data". A transaction that changed nothing says so, and
+  `begin_transaction()` is silent. The two lines they replace ("Transaction
+  started.", "Transaction committed.") said nothing about the snapshot; the
+  new one gives the version number that time travel uses.
+
+* The Getting Started article (`vignette("ducklake")`) is rewritten as one
+  short session: install, attach a lake, add a table, read it back, change
+  it, see its history, and detach, with the reasons to wrap changes in
+  `with_transaction()` explained along the way. Its recipes move to two new
+  articles. "Loading Data" (`vignette("loading-data")`) collects the ways
+  data gets into a lake, from data frames and files to registering Parquet
+  in place and migrating from DuckDB or Iceberg. "Views, Comments, and
+  Labels" (`vignette("views-comments-labels")`) covers the query logic and
+  documentation that live in the catalog, and its labels example uses
+  `labelled::set_variable_labels()`, so labelled is now a suggested
+  package.
+
 # ducklake 0.7.0
 
 * New article "Choosing a Deployment" (`vignette("deployment")`): what a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ducklake (development version)
+
 # ducklake 0.7.0
 
 * New article "Choosing a Deployment" (`vignette("deployment")`): what a

--- a/R/ducklake-package.R
+++ b/R/ducklake-package.R
@@ -1,7 +1,7 @@
 #' @section Package options:
 #' \describe{
 #'   \item{`ducklake.verbose`}{When `FALSE`, the confirmations the package
-#'     emits after each operation ("Transaction committed.", "Added column
+#'     emits after each operation ("Committed snapshot 3: ...", "Added column
 #'     ...") are suppressed, which keeps pipeline logs quiet. Warnings,
 #'     errors, and notices about extension downloads are unaffected. The
 #'     messages carry the condition class `ducklake_message`. Default

--- a/R/time_travel.R
+++ b/R/time_travel.R
@@ -361,7 +361,6 @@ restore_table_version <- function(table_name, version = NULL, timestamp = NULL,
       conn = conn
     )
     reapply_table_options(meta, conn)
-    dl_inform("Table {.val {table_name}} restored to {restore_point} (recorded as a new snapshot).")
     invisible(TRUE)
   }, error = function(e) {
     cli::cli_abort(c(

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -45,7 +45,9 @@ begin_transaction <- function(conn = NULL) {
   }
 
   DBI::dbExecute(conn, "BEGIN TRANSACTION;")
-  dl_inform("Transaction started.")
+  # Remember where the lake stood, so the commit can report whether it
+  # moved and to which snapshot
+  .ducklake_env$txn_snapshot_before <- current_snapshot_id(conn)
   invisible(TRUE)
 }
 
@@ -71,6 +73,14 @@ begin_transaction <- function(conn = NULL) {
 #' they will be set using \code{CALL ducklake.set_commit_message()} within the
 #' transaction before the \code{COMMIT} statement, as required by the DuckLake
 #' v1.0 specification.
+#'
+#' The commit is confirmed with one message naming the snapshot it created,
+#' with the author and commit message when they were given. The id is the
+#' newest snapshot in the lake right after the commit, so when several
+#' sessions write to the same lake it can belong to a commit that landed
+#' just after this one. A transaction that changed nothing creates no
+#' snapshot, and the message says so. `options(ducklake.verbose = FALSE)`
+#' silences these confirmations.
 #'
 #' @examplesIf ducklake_extension_available()
 #' lake_dir <- tempfile("commit_lake_")
@@ -155,7 +165,14 @@ commit_transaction <- function(
   }
 
   DBI::dbExecute(conn, "COMMIT;")
-  dl_inform("Transaction committed.")
+
+  # Report the snapshot this commit made. The template names locals of
+  # this frame, so user text is substituted as a value, never parsed as
+  # cli markup.
+  before <- .ducklake_env$txn_snapshot_before
+  .ducklake_env$txn_snapshot_before <- NULL
+  snapshot <- current_snapshot_id(conn)
+  dl_inform(commit_confirmation(snapshot, before, author, commit_message))
 
   invisible(TRUE)
 }
@@ -433,6 +450,46 @@ rollback_transaction <- function(conn = NULL) {
   }
 
   DBI::dbExecute(conn, "ROLLBACK;")
+  .ducklake_env$txn_snapshot_before <- NULL
   dl_inform("Transaction rolled back.")
   invisible(TRUE)
+}
+
+#' The lake's current snapshot id, or NA when it cannot be read
+#'
+#' Inside an open transaction this is the snapshot the transaction started
+#' from: DuckLake assigns the next id only at commit.
+#' @noRd
+current_snapshot_id <- function(conn) {
+  tryCatch(
+    {
+      name <- infer_ducklake_name(NULL, conn)
+      id <- DBI::dbGetQuery(
+        conn,
+        sprintf("FROM %s.current_snapshot()", quote_ident(name, conn))
+      )[[1]]
+      as.integer(id)
+    },
+    error = function(e) NA_integer_
+  )
+}
+
+#' The cli template for a commit confirmation
+#'
+#' Returns a template that refers to `snapshot`, `author`, and
+#' `commit_message` in the caller's frame, where `dl_inform()` interpolates
+#' them.
+#' @noRd
+commit_confirmation <- function(snapshot, before, author, commit_message) {
+  if (is.na(snapshot)) {
+    return("Transaction committed.")
+  }
+  if (isTRUE(snapshot == before)) {
+    return("Committed with no changes: the lake stays at snapshot {snapshot}.")
+  }
+  paste0(
+    "Committed snapshot {snapshot}",
+    if (!is.null(author)) " ({author})" else "",
+    if (!is.null(commit_message)) ": {commit_message}" else "."
+  )
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -189,10 +189,12 @@ dplyneage's [ducklake lineage vignette](https://tgerke.github.io/dplyneage/artic
 
 Check out the [pkgdown site](https://tgerke.github.io/ducklake-r/) for detailed vignettes:
 
-- [Getting Started](https://tgerke.github.io/ducklake-r/articles/ducklake.html) - Quick recipes for common operations
+- [Getting Started](https://tgerke.github.io/ducklake-r/articles/ducklake.html) - Attach a lake, add a table, read it back, change it, and see its history
+- [Loading Data](https://tgerke.github.io/ducklake-r/articles/loading-data.html) - Files, URLs, pipelines, schemas, Parquet in place, and migrating from DuckDB or Iceberg
 - [Choosing a Deployment](https://tgerke.github.io/ducklake-r/articles/deployment.html) - Which catalog, where the data goes, who can reach it, and what to set up on day one
 - [Clinical Trial Data Lake](https://tgerke.github.io/ducklake-r/articles/clinical-trial-datalake.html) - Complete workflow from SDTM to ADaM with regulatory artifacts
 - [Modifying Tables](https://tgerke.github.io/ducklake-r/articles/modifying-tables.html) - Choosing how to change a table: joins vs. `rows_*`, upserts, `merge_into()`, and `replace_table()`
+- [Views, Comments, and Labels](https://tgerke.github.io/ducklake-r/articles/views-comments-labels.html) - Shared query logic and documentation that live in the lake
 - [Data Inlining](https://tgerke.github.io/ducklake-r/articles/data-inlining.html) - Streaming-friendly small writes
 - [Transactions](https://tgerke.github.io/ducklake-r/articles/transactions.html) - ACID transaction support
 - [Time Travel](https://tgerke.github.io/ducklake-r/articles/time-travel.html) - Query and restore historical data

--- a/README.md
+++ b/README.md
@@ -261,7 +261,12 @@ detailed vignettes:
 
 - [Getting
   Started](https://tgerke.github.io/ducklake-r/articles/ducklake.html) -
-  Quick recipes for common operations
+  Attach a lake, add a table, read it back, change it, and see its
+  history
+- [Loading
+  Data](https://tgerke.github.io/ducklake-r/articles/loading-data.html) -
+  Files, URLs, pipelines, schemas, Parquet in place, and migrating from
+  DuckDB or Iceberg
 - [Choosing a
   Deployment](https://tgerke.github.io/ducklake-r/articles/deployment.html) -
   Which catalog, where the data goes, who can reach it, and what to set
@@ -273,6 +278,9 @@ detailed vignettes:
   Tables](https://tgerke.github.io/ducklake-r/articles/modifying-tables.html) -
   Choosing how to change a table: joins vs. `rows_*`, upserts,
   `merge_into()`, and `replace_table()`
+- [Views, Comments, and
+  Labels](https://tgerke.github.io/ducklake-r/articles/views-comments-labels.html) -
+  Shared query logic and documentation that live in the lake
 - [Data
   Inlining](https://tgerke.github.io/ducklake-r/articles/data-inlining.html) -
   Streaming-friendly small writes

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -30,8 +30,12 @@ navbar:
         href: articles/clinical-trial-datalake.html
       - text: -------
       - text: Core Operations
+      - text: Loading Data
+        href: articles/loading-data.html
       - text: Modifying Tables
         href: articles/modifying-tables.html
+      - text: Views, Comments, and Labels
+        href: articles/views-comments-labels.html
       - text: -------
       - text: Advanced Features
       - text: Data Inlining

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -3,6 +3,7 @@ ADPC
 ADSL
 ADaM
 AE
+AES
 ARD
 Analytics
 Atomicity
@@ -52,6 +53,8 @@ SDTM
 SMB
 SUPPDM
 Scalability
+Schemas
+Stata
 TLS
 Tidyverse
 Tunable

--- a/man/commit_transaction.Rd
+++ b/man/commit_transaction.Rd
@@ -35,6 +35,14 @@ If \code{author}, \code{commit_message}, or \code{commit_extra_info} are provide
 they will be set using \code{CALL ducklake.set_commit_message()} within the
 transaction before the \code{COMMIT} statement, as required by the DuckLake
 v1.0 specification.
+
+The commit is confirmed with one message naming the snapshot it created,
+with the author and commit message when they were given. The id is the
+newest snapshot in the lake right after the commit, so when several
+sessions write to the same lake it can belong to a commit that landed
+just after this one. A transaction that changed nothing creates no
+snapshot, and the message says so. \code{options(ducklake.verbose = FALSE)}
+silences these confirmations.
 }
 \examples{
 \dontshow{if (ducklake_extension_available()) withAutoprint(\{ # examplesIf}

--- a/man/ducklake-package.Rd
+++ b/man/ducklake-package.Rd
@@ -14,7 +14,7 @@ A 'tidyverse'-friendly interface to 'DuckLake' \url{https://ducklake.select/}, t
 
 \describe{
 \item{\code{ducklake.verbose}}{When \code{FALSE}, the confirmations the package
-emits after each operation ("Transaction committed.", "Added column
+emits after each operation ("Committed snapshot 3: ...", "Added column
 ...") are suppressed, which keeps pipeline logs quiet. Warnings,
 errors, and notices about extension downloads are unaffected. The
 messages carry the condition class \code{ducklake_message}. Default

--- a/tests/testthat/test-transactions.R
+++ b/tests/testthat/test-transactions.R
@@ -1,0 +1,87 @@
+# UNIT TESTS: transaction confirmations
+#
+# begin_transaction() is silent. commit_transaction() reports the snapshot
+# the transaction created, with its author and message, or says that
+# nothing changed.
+
+capture_ducklake_messages <- function(expr) {
+  msgs <- character()
+  withCallingHandlers(
+    expr,
+    message = function(m) {
+      msgs <<- c(msgs, conditionMessage(m))
+      invokeRestart("muffleMessage")
+    }
+  )
+  msgs
+}
+
+test_that("commit_transaction reports the snapshot it created", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  expect_silent(begin_transaction())
+  create_table(data.frame(id = 1:3), "confirm_t")
+  msgs <- capture_ducklake_messages(
+    commit_transaction(author = "Tester", commit_message = "first load")
+  )
+  expect_length(msgs, 1)
+  expect_match(msgs, "Committed snapshot [0-9]+ \\(Tester\\): first load")
+  reported <- as.integer(sub(".*Committed snapshot ([0-9]+).*", "\\1", msgs))
+  expect_equal(reported, max(list_table_snapshots()$snapshot_id))
+
+  # Without metadata the line ends after the id
+  begin_transaction()
+  rows_insert(get_ducklake_table("confirm_t"), data.frame(id = 4L), by = "id")
+  expect_message(commit_transaction(), "Committed snapshot [0-9]+\\.")
+})
+
+test_that("a commit that changed nothing says so", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  before <- max(list_table_snapshots()$snapshot_id)
+  begin_transaction()
+  expect_message(commit_transaction(author = "Tester"), "no changes")
+  expect_equal(max(list_table_snapshots()$snapshot_id), before)
+})
+
+test_that("with_transaction emits a single confirmation", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  msgs <- capture_ducklake_messages(
+    with_transaction(
+      create_table(data.frame(id = 1:2), "single_t"),
+      author = "Tester",
+      commit_message = "one line"
+    )
+  )
+  expect_length(msgs, 1)
+  expect_match(msgs, "Committed snapshot [0-9]+ \\(Tester\\): one line")
+})
+
+test_that("rollback clears the pending confirmation", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  create_table(data.frame(id = 1:2), "rb_t")
+  begin_transaction()
+  expect_false(is.null(get_ducklake_env()$txn_snapshot_before))
+  rows_insert(get_ducklake_table("rb_t"), data.frame(id = 3L), by = "id")
+  expect_message(rollback_transaction(), "rolled back")
+  expect_null(get_ducklake_env()$txn_snapshot_before)
+  expect_equal(nrow(dplyr::collect(get_ducklake_table("rb_t"))), 2)
+})

--- a/tests/testthat/test-vignette-workflows.R
+++ b/tests/testthat/test-vignette-workflows.R
@@ -5,7 +5,7 @@
 # work as documented, rather than testing individual low-level functions.
 #
 # Each test corresponds to a specific vignette:
-# - ducklake.Rmd: Basic create/update workflow
+# - ducklake.Rmd: create a table, change it, read a version, restore it
 # - time-travel.Rmd: Version history and time travel queries
 # - clinical-trial-datalake.Rmd: Medallion architecture with related tables
 # - transactions.Rmd: Manual transaction control with rollback
@@ -163,16 +163,19 @@ test_that("ducklake.Rmd workflow: create lake, load data, update table", {
   result <- get_ducklake_table("cars") |> dplyr::collect()
   expect_equal(nrow(result), nrow(mtcars))
 
-  # Update an existing table (as shown in vignette)
-  with_transaction(
+  # Change the table in place (as shown in vignette): declare a column,
+  # then fill it, as one snapshot
+  with_transaction({
+    add_table_column("cars", "kpl", "DOUBLE")
     get_ducklake_table("cars") |>
       dplyr::mutate(kpl = mpg * 0.425144) |>
-      replace_table("cars"),
+      ducklake_exec()
+  },
     author = "Data Engineer",
-    commit_message = "Add km/L metric"
+    commit_message = "Add fuel efficiency in km/L"
   )
 
-  # Verify the update worked
+  # Verify the change worked
   result2 <- get_ducklake_table("cars") |> dplyr::collect()
   expect_true("kpl" %in% names(result2))
   expect_equal(nrow(result2), nrow(mtcars))
@@ -181,6 +184,16 @@ test_that("ducklake.Rmd workflow: create lake, load data, update table", {
   snapshots <- list_table_snapshots("cars")
   expect_equal(nrow(snapshots), 2)
   expect_true(all(c("snapshot_id", "snapshot_time", "changes") %in% names(snapshots)))
+
+  # The first version is still readable without the new column, and a
+  # restore brings it back as a third snapshot
+  first_id <- snapshots$snapshot_id[[1]]
+  expect_false(
+    "kpl" %in% colnames(get_ducklake_table_version("cars", version = first_id))
+  )
+  restore_table_version("cars", version = first_id, author = "Data Engineer")
+  expect_false("kpl" %in% colnames(get_ducklake_table("cars")))
+  expect_equal(nrow(list_table_snapshots("cars")), 3)
 
   cleanup_temp_ducklake(lake)
 })

--- a/vignettes/deployment.Rmd
+++ b/vignettes/deployment.Rmd
@@ -139,6 +139,14 @@ latency per file. Sorting and partitioning large tables
 (`set_table_sorting()`, `set_table_partitioning()`) matter most on object
 storage, where every file skipped is a request avoided.
 
+```{r pruning}
+# Sorting suits high-cardinality columns like timestamps or ids
+set_table_sorting("events", "event_time")
+
+# Partitioning suits low-cardinality columns like year or region
+set_table_partitioning("sales", c("year(order_date)", "region"))
+```
+
 ## Who can reach it
 
 DuckLake has no user accounts of its own. Access control lives in the two
@@ -225,7 +233,8 @@ attach_ducklake("trial", lake_path = "~/lakes/trial", automatic_migration = TRUE
 
 ## Where to next
 
-- `vignette("ducklake")` for recipes covering the everyday operations
+- `vignette("ducklake")` to attach a lake, add a table, and follow its history
+- `vignette("loading-data")` for files, URLs, Parquet in place, and migrating from DuckDB or Iceberg
 - `vignette("storage-and-backups")` for the file layout, backups, and maintenance
 - `vignette("transactions")` for commit metadata and working with several writers
 - `vignette("quack-remote-access")` for serving a lake over the network

--- a/vignettes/ducklake.Rmd
+++ b/vignettes/ducklake.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "ducklake Cookbook"
+title: "Getting Started with ducklake"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{ducklake Cookbook}
+  %\VignetteIndexEntry{Getting Started with ducklake}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -28,552 +28,215 @@ library(ducklake)
 library(dplyr)
 ```
 
-## Introduction
+## What a DuckLake is
 
-This cookbook provides quick recipes for common ducklake operations. Each recipe is a self-contained example you can adapt for your workflow.
+A DuckLake is a data lake that keeps its own history. Two pieces make it
+up: a catalog database that records every table, column, and change, and a
+directory of Parquet files that holds the rows. Every committed change
+becomes a snapshot, and any snapshot can be read again later, so a table's
+past is part of the table. ducklake puts dplyr on top of this. You attach a
+lake, add tables, and query them as lazy tables, and DuckDB does the work.
 
-For a comprehensive real-world example, see the [clinical trial data lake](clinical-trial-datalake.html) vignette.
+This article follows one short session: attach a lake, add a table, read
+it back, change it, look at its history, and detach.
+[Choosing a Deployment](deployment.html) describes what a lake looks like
+on disk and where the catalog and the data files can live.
 
-## Setup recipes
+## Install
 
-### Create a new data lake
+```{r install, eval = FALSE}
+install.packages("ducklake")
 
-```{r create, message=FALSE}
-# Create a data lake in a specific directory
+# The DuckLake extension for DuckDB is downloaded once per machine
+install_ducklake()
+```
+
+ducklake needs the duckdb package at version 1.5.2 or newer. From that
+version on, DuckDB keeps downloaded extensions in a temporary directory
+that disappears with the session, unless `DUCKDB_R_HOME` points somewhere
+permanent. Setting it in `~/.Renviron` (for example
+`DUCKDB_R_HOME=~/.duckdb`) makes the download a one-time event.
+
+## Attach a lake
+
+One call opens a lake, and creates it first when nothing is at the path
+yet:
+
+```{r attach, message=FALSE}
 attach_ducklake("my_lake", lake_path = vignette_temp_dir)
 ```
 
-### Attach to an existing data lake
+The same call with the same path opens the lake again in a later session.
+When you know a lake already exists, add `create = FALSE`: a mistyped path
+then stops with an error instead of creating a new, empty lake.
 
-```{r attach, eval=FALSE}
-# Attach to an existing lake (creates it if it doesn't exist)
-attach_ducklake("existing_lake", lake_path = "/path/to/data_lake")
-```
+By default the catalog is a DuckDB database file stored next to the data,
+which is the right setup for one person on one machine. A lake that several
+people write to keeps its catalog in SQLite or PostgreSQL instead, and that
+is a one-argument change to this call.
+[Choosing a Deployment](deployment.html) walks through the options.
 
-### Use an alternative catalog backend
+## Add a table
 
-```{r attach-postgres, eval=FALSE}
-# PostgreSQL catalog for multi-client access
-attach_ducklake(
-  "shared_lake",
-  backend = "postgres",
-  catalog_connection_string = "dbname=ducklake_catalog host=localhost",
-  lake_path = "/shared/lake/data/"
-)
+`create_table()` takes a data frame and writes it into the lake as a new
+table. Wrapped in `with_transaction()`, the table is committed as one
+snapshot with a record of who added it and why:
 
-# SQLite catalog for lightweight local multi-client setups
-attach_ducklake(
-  "team_lake",
-  backend = "sqlite",
-  catalog_connection_string = "metadata.sqlite",
-  lake_path = "data_files/"
-)
-```
-
-### Detach from a data lake
-
-```{r detach, eval=FALSE}
-# Detach when done (doesn't delete the lake)
-detach_ducklake("my_lake")
-```
-
-## Loading data recipes
-
-### Load data from a data.frame
-
-```{r load_df}
+```{r add_table}
 with_transaction(
   create_table(mtcars, "cars"),
   author = "Data Engineer",
-  commit_message = "Initial car data load"
+  commit_message = "Add the Motor Trend car data"
 )
-```
-
-### Add a derived column in place
-
-```{r update_cars}
-# A new column is a metadata change; filling it is an in-database UPDATE.
-# Together they make the second version of the cars table.
-with_transaction({
-  add_table_column("cars", "kpl", "DOUBLE")
-  get_ducklake_table("cars") |>
-    mutate(kpl = mpg * 0.425144) |>  # km/L conversion
-    ducklake_exec()
-},
-  author = "Data Engineer",
-  commit_message = "Add km/L metric to cars table"
-)
-```
-
-### Load data from a CSV file
-
-```{r load_csv}
-# First write a sample CSV (in practice, you'd have an existing file)
-csv_path <- file.path(vignette_temp_dir, "sample_data.csv")
-write.csv(head(iris, 20), csv_path, row.names = FALSE)
-
-# Load the CSV into the data lake
-with_transaction(
-  create_table(csv_path, "iris_sample"),
-  author = "Data Engineer",
-  commit_message = "Load iris sample from CSV"
-)
-```
-
-### Load data from a URL
-
-```{r load_url, eval=FALSE}
-# ducklake can load data directly from URLs
-with_transaction(
-  create_table("https://example.com/data.csv", "remote_data"),
-  author = "Data Engineer",
-  commit_message = "Load remote dataset"
-)
-```
-
-### Register existing Parquet files without copying
-
-If your data is already in Parquet, `add_data_files()` records the files in
-the lake in place -- no copy, no rewrite, and no collection into R. A vector
-of files is registered atomically in one snapshot. This is the fast migration
-path from a folder of Parquet extracts. The target table can already exist
-with a compatible schema, or `create = TRUE` can create it directly from the
-Parquet schema. Note that the lake takes ownership of the files: later
-compaction may rewrite or delete them.
-
-```{r add_data_files, eval=FALSE}
-add_data_files(
-  "readings",
-  c("extracts/jan.parquet", "extracts/feb.parquet"),
-  create = TRUE
-)
-
-# See which files back a table
-list_ducklake_files("readings")
-```
-
-### Migrate an existing DuckDB database
-
-A DuckDB database file moves into the lake with one statement: attach it
-read-only and copy every schema and table across. The copy lands as a
-single snapshot.
-
-```{r migrate_duckdb}
-legacy_db <- file.path(vignette_temp_dir, "legacy.duckdb")
-legacy <- DBI::dbConnect(duckdb::duckdb(dbdir = legacy_db))
-DBI::dbWriteTable(
-  legacy, "sites",
-  data.frame(site_id = 1:3, country = c("US", "DE", "JP"))
-)
-DBI::dbDisconnect(legacy, shutdown = TRUE)
-
-conn <- get_ducklake_connection()
-DBI::dbExecute(conn, sprintf("ATTACH '%s' AS legacy (READ_ONLY);", legacy_db))
-DBI::dbExecute(conn, "COPY FROM DATABASE legacy TO my_lake;")
-DBI::dbExecute(conn, "DETACH legacy;")
-
-get_ducklake_table("sites") |> collect()
-```
-
-Types DuckLake does not support (`ENUM`, `UNION`, `VARINT`, fixed-size
-arrays) need converting first; the DuckLake documentation has a migration
-script for those cases:
-<https://ducklake.select/docs/stable/duckdb/migrations/duckdb_to_ducklake>.
-
-### Exchange data with Iceberg
-
-With DuckDB's iceberg extension attached to an Iceberg REST catalog,
-`COPY FROM DATABASE` moves tables in either direction. Copying into Iceberg
-needs the schemas to exist there first, and the copy adds tables rather
-than replacing them.
-
-```{r iceberg, eval=FALSE}
-DBI::dbExecute(conn, "INSTALL iceberg; LOAD iceberg;")
-DBI::dbExecute(conn, "
-  ATTACH '' AS iceberg_catalog (
-    TYPE iceberg,
-    CLIENT_ID 'admin',
-    CLIENT_SECRET 'password',
-    ENDPOINT 'http://iceberg.example.org:8181'
-  );
-")
-
-# Lake to Iceberg
-DBI::dbExecute(conn, "COPY FROM DATABASE my_lake TO iceberg_catalog;")
-
-# Iceberg to lake: the data itself, or only the metadata, so that Iceberg
-# tables read as lake tables where they are
-DBI::dbExecute(conn, "COPY FROM DATABASE iceberg_catalog TO my_lake;")
-DBI::dbExecute(conn, "CALL iceberg_to_ducklake('iceberg_catalog', 'my_lake');")
-```
-
-### Load with a dplyr pipeline
-
-```{r load_pipeline}
-with_transaction(
-  mtcars |>
-    filter(mpg > 20) |>
-    create_table("efficient_cars"),
-  author = "Data Analyst",
-  commit_message = "Load filtered car data"
-)
-```
-
-### Derive a table from another table, inside the database
-
-A pipeline built on `get_ducklake_table()` is written with
-`CREATE TABLE ... AS` in DuckDB: the rows never pass through R, and column
-labels follow the columns into the new table.
-
-```{r derive_in_db}
-with_transaction(
-  get_ducklake_table("cars") |>
-    filter(cyl == 4) |>
-    select(mpg, cyl, hp, wt) |>
-    create_table("small_cars"),
-  author = "Data Analyst",
-  commit_message = "Four-cylinder subset"
-)
-```
-
-### List all tables in the lake
-
-```{r list_all_tables}
-# Every table and view, with its schema and type
-list_ducklake_tables()
-```
-
-### Organize tables in schemas
-
-Schemas group tables inside the lake. They suit medallion layers
-(`bronze`, `silver`, `gold`) or one area per study, and every function that
-takes a table name accepts `"schema.table"`:
-
-```{r schemas}
-create_schema("staging")
-create_table(mtcars, "staging.cars_raw")
-
-get_ducklake_table("staging.cars_raw") |>
-  count(cyl)
 
 list_ducklake_tables()
 ```
 
-## Shared logic and documentation recipes
+The confirmation names the snapshot the commit created. That number is the
+table's version, and the history section below uses it to look back.
 
-### Store a pipeline as a view
+### Why most calls sit inside `with_transaction()`
 
-A view stores a query, not data: reads always run against the current
-tables, and every client of the lake -- R, Python, or plain SQL -- sees the
-same definition.
+Every change to a lake is a commit. Called on its own, `create_table()`
+still commits, as one snapshot without an author or a message.
+`with_transaction()` makes the commit explicit. It groups everything inside
+it into a single snapshot, records who made the change and why, and rolls
+everything back if any step fails, so a half-finished change never lands
+in the lake.
 
-```{r create_view}
-get_ducklake_table("cars") |>
-  filter(mpg > 25) |>
-  create_view("v_efficient_cars")
+The first argument is one R expression. A single call needs nothing more.
+To commit several operations as one snapshot, wrap them in braces, exactly
+as you would write the body of a function. The change below does that.
 
-get_ducklake_table("v_efficient_cars") |> collect()
-```
+Three fields describe a commit. `author` and `commit_message` are the ones
+to use every time. `commit_extra_info` holds free-form context, such as a
+ticket number or a JSON string, and it appears alongside the other two in
+the snapshot history. [Working with Transactions](transactions.html)
+covers all three, manual transaction control, and what happens when
+several sessions write at once.
 
-Drop it when the logic is no longer needed:
+## Read a table
 
-```{r drop_view}
-drop_view("v_efficient_cars")
-```
+`get_ducklake_table()` returns a lazy table. Nothing is read until you ask
+for it, and the dplyr verbs you pipe onto it become SQL that DuckDB runs
+against the lake:
 
-For logic a view cannot hold -- a parameterized SQL macro, say -- DuckDB
-SQL is the escape hatch:
-`DBI::dbExecute(get_ducklake_connection(), "CREATE MACRO ...")`.
-
-### Document tables and columns
-
-Comments live in the lake's catalog, so the documentation travels with the
-data instead of in a sidecar file:
-
-```{r comments}
-set_table_comment("cars", "Motor Trend road tests of 1973-74 models")
-set_column_comments(
-  "cars",
-  mpg = "Miles per US gallon",
-  wt = "Weight (1000 lbs)"
-)
-
-get_table_comments("cars")
-```
-
-### Keep variable labels through the lake
-
-If your data carries haven/labelled-style variable labels, they survive
-the lake: `create_table()` stores `label` attributes as column comments,
-and `collect()` puts them back, so label-aware tools like gtsummary and gt
-behave as if the data never left R.
-
-```{r labels}
-df_visits <- data.frame(subject = c("S1", "S2"), sbp = c(128, 141))
-attr(df_visits$subject, "label") <- "Subject identifier"
-attr(df_visits$sbp, "label") <- "Systolic blood pressure (mmHg)"
-
-create_table(df_visits, "visits")
-
-collected <- get_ducklake_table("visits") |> collect()
-attr(collected$sbp, "label")
-```
-
-## Reading data recipes
-
-### Read a table
-
-```{r read_table}
-# Returns a lazy dplyr tbl
+```{r read}
 cars_data <- get_ducklake_table("cars")
 
-# Use dplyr verbs
 cars_data |>
   filter(cyl == 6) |>
   select(mpg, cyl, hp) |>
   head(3)
 ```
 
-### Collect data into memory
+`show_query()` prints the SQL a pipeline will run. `collect()` runs it and
+returns a tibble:
 
 ```{r collect}
-# Fetch all data into a data.frame
-cars_df <- get_ducklake_table("cars") |> collect()
-head(cars_df, 3)
-```
-
-### View all versions of a table
-
-```{r view_versions}
-# See all snapshots for the cars table
-list_table_snapshots("cars")
-```
-
-### Read a specific version
-
-```{r read_version}
-# Query data as it existed at snapshot 1 -- before the kpl column was added
-get_ducklake_table_version("cars", version = 1) |>
-  select(mpg, cyl, hp) |>
-  head(3)
-```
-
-### Read data at a specific timestamp
-
-```{r read_timestamp, eval=FALSE}
-# Query data as of a specific time (see list_table_snapshots() for times)
-get_ducklake_table_asof("cars", timestamp = "2024-01-15 10:30:00") |>
-  collect()
-```
-
-## Updating data recipes
-
-### Correct rows in place
-
-```{r update_in_place}
-# filter() becomes the WHERE clause of a single UPDATE
-with_transaction(
-  get_ducklake_table("cars") |>
-    filter(cyl == 8) |>
-    mutate(hp = hp * 1.02) |>
-    ducklake_exec(),
-  author = "Data Engineer",
-  commit_message = "Apply the dyno correction to V8 engines"
-)
-```
-
-### Replace entire table
-
-```{r replace_table}
-# A bulk rewrite that touches most rows: the whole table is rewritten, and
-# its comments, partition keys, sort order, and options carry over
-with_transaction(
-  get_ducklake_table("cars") |>
-    mutate(across(c(mpg, kpl), ~ round(.x, 1))) |>
-    replace_table("cars"),
-  author = "Data Engineer",
-  commit_message = "Round fuel efficiency metrics"
-)
-```
-
-Note: use the schema evolution functions (`add_table_column()` and friends) for structural changes, `ducklake_exec()` and the row-level operations (`rows_update()`, `rows_insert()`, `rows_delete()`, `rows_upsert()`) for targeted changes, and `replace_table()` for bulk rewrites. All are fully versioned: every committed change creates a snapshot you can time-travel back to. See `vignette("modifying-tables")` for guidance on choosing between them.
-
-## Metadata and versioning recipes
-
-### View all snapshots
-
-```{r list_snapshots}
-list_table_snapshots()
-```
-
-### View snapshots for a specific table
-
-```{r list_table_snapshots, eval=FALSE}
-list_table_snapshots("cars")
-```
-
-### Restore a table to a previous version
-
-```{r restore}
-# Roll cars back to snapshot 1. The restore is recorded as a new snapshot,
-# so nothing is lost -- you can still time-travel to any version.
-restore_table_version(
-  "cars",
-  version = 1,
-  author = "Data Engineer"
-)
-
-list_table_snapshots("cars")
-```
-
-## Transaction recipes
-
-### Simple transaction
-
-```{r simple_transaction, eval=FALSE}
-with_transaction(
-  create_table(my_data, "my_table"),
-  author = "Your Name",
-  commit_message = "What changed and why"
-)
-```
-
-### Multi-step transaction
-
-```{r multi_step, eval=FALSE}
-with_transaction({
-  # All these operations happen atomically
-  create_table(raw_data, "raw_table")
-  
-  cleaned <- get_ducklake_table("raw_table") |>
-    filter(!is.na(key_field)) |>
-    create_table("clean_table")
-  
-  get_ducklake_table("clean_table") |>
-    mutate(derived_field = calculate_something(x)) |>
-    create_table("analysis_table")
-},
-author = "Data Engineer",
-commit_message = "Full ETL pipeline run"
-)
-```
-
-### Manual transaction control
-
-```{r manual_transaction, eval=FALSE}
-# For fine-grained control
-begin_transaction()
-
-create_table(data1, "table1")
-create_table(data2, "table2")
-
-# Commit or rollback
-commit_transaction(
-  author = "Your Name",
-  commit_message = "Manual transaction commit"
-)
-
-# Or if something went wrong:
-# rollback_transaction()
-```
-
-## Query optimization recipes
-
-### Preview query without execution
-
-To see the SQL a *read* pipeline will run, use dplyr's `show_query()`:
-
-```{r show_query}
-get_ducklake_table("cars") |>
-  filter(mpg > 25) |>
+cars_data |>
+  filter(cyl == 6) |>
   select(mpg, cyl, hp) |>
   show_query()
-```
 
-To preview the SQL an in-place *modification* would run (before committing
-to it with `ducklake_exec()`), use `show_ducklake_query()`:
-
-```{r show_ducklake_query}
-get_ducklake_table("cars") |>
-  mutate(mpg = round(mpg)) |>
-  show_ducklake_query()
-```
-
-### Filter early for performance
-
-```{r filter_early}
-# Good: Filter before other operations
-get_ducklake_table("cars") |>
+df_six <- cars_data |>
   filter(cyl == 6) |>
-  mutate(kpl = mpg * 0.425144) |>
+  select(mpg, cyl, hp) |>
+  collect()
+
+df_six
+```
+
+Filter and select before you collect. DuckDB then reads only the rows and
+columns you need, which matters once a table is larger than memory.
+
+## Change a table
+
+A change is a transaction like any other. Here two steps make one
+snapshot: a new column is declared, then filled in place by a dplyr
+pipeline that `ducklake_exec()` turns into an `UPDATE`. The braces commit
+both steps as a unit:
+
+```{r change}
+with_transaction({
+  add_table_column("cars", "kpl", "DOUBLE")
+  get_ducklake_table("cars") |>
+    mutate(kpl = mpg * 0.425144) |>
+    ducklake_exec()
+},
+  author = "Data Engineer",
+  commit_message = "Add fuel efficiency in km/L"
+)
+
+get_ducklake_table("cars") |>
+  select(mpg, kpl) |>
   head(3)
 ```
 
-### Use specific columns
+[Modifying Tables](modifying-tables.html) covers the other ways to change
+a table: `rows_insert()`, `rows_update()`, and `rows_delete()` for specific
+rows, `rows_upsert()` and `merge_into()` for batches, and `replace_table()`
+for a bulk rewrite. All of them are versioned in the same way.
 
-```{r select_columns}
-# Good: Select only needed columns
-get_ducklake_table("cars") |>
-  select(mpg, cyl, hp) |>
-  filter(mpg > 25)
+## See the history
+
+`list_table_snapshots()` lists every snapshot that touched a table:
+
+```{r history}
+list_table_snapshots("cars")
 ```
 
-### Sort or partition large tables for file pruning
+Each row is one commit. `changes` summarizes what the commit did,
+`author`, `commit_message`, and `commit_extra_info` are the fields passed
+to `with_transaction()`, and `snapshot_id` is the number from the
+confirmation. Any earlier version can be read as a lazy table:
 
-For big tables, declaring a sort order or partition keys lets DuckLake skip
-whole Parquet files when a query filters on those columns:
-
-```{r sorting_partitioning, eval=FALSE}
-# Sorting suits high-cardinality columns like timestamps or ids
-set_table_sorting("events", "event_time")
-
-# Partitioning suits low-cardinality columns like year or region
-set_table_partitioning("sales", c("year(order_date)", "region"))
+```{r version}
+# The cars table before the kpl column existed
+get_ducklake_table_version("cars", version = 1) |>
+  head(3)
 ```
 
-### Tune lake options
+A table can also be put back the way it was. The restore is a new
+snapshot, so the versions after it stay readable:
 
-`set_ducklake_option()` adjusts DuckLake's persisted settings at lake,
-schema, or table scope, and `get_ducklake_options()` shows what's set:
+```{r restore}
+restore_table_version("cars", version = 1, author = "Data Engineer")
 
-```{r options, eval=FALSE}
-# Trade write speed for smaller files
-set_ducklake_option("parquet_compression", "zstd")
-
-# Require a commit message on every snapshot -- useful for audit discipline
-set_ducklake_option("require_commit_message", TRUE)
-
-get_ducklake_options()
+list_table_snapshots("cars")
 ```
 
-## Maintenance recipes
+[Time Travel](time-travel.html) covers reading a table as of a timestamp,
+comparing versions, and pinning a whole session to one snapshot.
 
-### Set a retention policy and checkpoint
+## Detach
 
-```{r retention, eval=FALSE}
-# Keep 90 days of time travel; delete released files a week after release
-set_ducklake_option("expire_older_than", "90 days")
-set_ducklake_option("delete_older_than", "7 days")
-
-# Flush, compact, and apply the policy
-checkpoint_ducklake()
-```
-
-Without those two options a checkpoint still flushes inlined data and
-compacts files, but expires nothing and deletes nothing. See
-`vignette("storage-and-backups")` for the individual maintenance functions
-and for backups.
-
-## Cleanup
-
-```{r cleanup}
-# Detach from the lake
+```{r detach}
 detach_ducklake("my_lake")
 ```
 
-## See also
+Detaching deletes nothing. It matters because DuckDB holds a lock on the
+catalog file while the lake is attached, so another R session, a backup, or
+a restore cannot open the lake until this one lets go.
+`detach_ducklake("my_lake", shutdown = TRUE)` also closes the DuckDB
+connection. Attaching the same path again picks up where you left off,
+history included.
 
-- [Modifying Tables](modifying-tables.html) - Detailed guide to table modification approaches
-- [Transactions](transactions.html) - Advanced transaction patterns
-- [Time Travel](time-travel.html) - Comprehensive time travel guide
-- [Clinical Trial Data Lake](clinical-trial-datalake.html) - Complete real-world workflow
+## Where to go next
+
+- [Loading Data](loading-data.html): files, URLs, pipelines, schemas,
+  Parquet files that are already on disk, and migrating from DuckDB or
+  Iceberg.
+- [Modifying Tables](modifying-tables.html): choosing between row
+  operations, upserts, merges, and rewrites.
+- [Views, Comments, and Labels](views-comments-labels.html): shared query
+  logic and documentation that live in the lake.
+- [Working with Transactions](transactions.html): commit metadata, manual
+  control, and several writers at once.
+- [Time Travel](time-travel.html): every way to read the past.
+- [Choosing a Deployment](deployment.html): catalog backends, object
+  storage, access, and day-one settings.
+- [Storage and Backups](storage-and-backups.html): the files on disk,
+  backups, and maintenance.
+- [Clinical Trial Data Lake](clinical-trial-datalake.html): a complete
+  regulated workflow.

--- a/vignettes/loading-data.Rmd
+++ b/vignettes/loading-data.Rmd
@@ -1,0 +1,235 @@
+---
+title: "Loading Data"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Loading Data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+# Evaluate chunks only where the ducklake DuckDB extension is already
+# installed. The probe never downloads anything, so building this vignette
+# needs no network access.
+ducklake_available <- ducklake::ducklake_extension_available()
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = ducklake_available
+)
+# Use a unique temp directory for this vignette to avoid conflicts during R CMD check
+vignette_temp_dir <- file.path(tempdir(), "loading_data_vignette")
+dir.create(vignette_temp_dir, showWarnings = FALSE, recursive = TRUE)
+knitr::opts_knit$set(root.dir = vignette_temp_dir)
+```
+
+```{r setup, message=FALSE}
+library(ducklake)
+library(dplyr)
+
+attach_ducklake("loading_lake", lake_path = vignette_temp_dir)
+```
+
+`create_table()` is the one entry point for data that is not in the lake
+yet. It accepts a data frame, a path to a file, a URL, or a lazy table, and
+in every case the result is a new table and a new snapshot. The recipes
+below start with the everyday cases and end with the migration paths:
+registering Parquet files that already exist, and copying whole databases
+in from DuckDB or Iceberg.
+
+Each load here is wrapped in `with_transaction()` so that the snapshot
+carries an author and a message. [Getting Started](ducklake.html) explains
+why.
+
+## From a data frame
+
+```{r data_frame}
+with_transaction(
+  create_table(mtcars, "cars"),
+  author = "Data Engineer",
+  commit_message = "Add the Motor Trend car data"
+)
+```
+
+Factor columns become character columns on the way in, because DuckLake
+has no `ENUM` type, and `create_table()` says so when it happens:
+
+```{r factors}
+with_transaction(
+  create_table(iris, "flowers"),
+  author = "Data Engineer",
+  commit_message = "Add the iris measurements"
+)
+```
+
+Variable labels (the `label` attributes that haven and labelled use) are
+stored as column comments and come back on `collect()`.
+[Views, Comments, and Labels](views-comments-labels.html) shows the round
+trip.
+
+## From a file
+
+A file path goes straight to DuckDB's readers, so CSV, Parquet, and JSON
+files all load with the same call:
+
+```{r csv}
+csv_path <- file.path(vignette_temp_dir, "sample_data.csv")
+write.csv(head(iris, 20), csv_path, row.names = FALSE)
+
+with_transaction(
+  create_table(csv_path, "iris_sample"),
+  author = "Data Engineer",
+  commit_message = "Load the iris sample from CSV"
+)
+
+get_ducklake_table("iris_sample") |> head(3)
+```
+
+## From a URL
+
+An `http://` or `https://` address works the same way. ducklake loads
+DuckDB's `httpfs` extension for it:
+
+```{r url, eval=FALSE}
+with_transaction(
+  create_table("https://example.com/data.csv", "remote_data"),
+  author = "Data Engineer",
+  commit_message = "Load the remote dataset"
+)
+```
+
+## From a dplyr pipeline
+
+A pipeline on an R data frame is collected and written like any other data
+frame:
+
+```{r pipeline}
+with_transaction(
+  mtcars |>
+    filter(mpg > 20) |>
+    create_table("efficient_cars"),
+  author = "Data Analyst",
+  commit_message = "Add the cars above 20 mpg"
+)
+```
+
+## Derive a table inside the database
+
+When the pipeline starts from a lake table, `create_table()` runs it as
+`CREATE TABLE ... AS` inside DuckDB. The rows never pass through R, and
+column labels follow the columns into the new table:
+
+```{r derive}
+with_transaction(
+  get_ducklake_table("cars") |>
+    filter(cyl == 4) |>
+    select(mpg, cyl, hp, wt) |>
+    create_table("small_cars"),
+  author = "Data Analyst",
+  commit_message = "Four-cylinder subset"
+)
+```
+
+This is the shape of a medallion pipeline: each layer is a query on the
+layer before it, written straight into the lake.
+
+## Put tables in schemas
+
+Schemas group tables inside the lake. They suit medallion layers
+(`bronze`, `silver`, `gold`) or one area per study, and every function that
+takes a table name accepts `"schema.table"`:
+
+```{r schemas}
+with_transaction({
+  create_schema("staging")
+  create_table(mtcars, "staging.cars_raw")
+},
+  author = "Data Engineer",
+  commit_message = "Stage the raw car data"
+)
+
+get_ducklake_table("staging.cars_raw") |>
+  count(cyl)
+
+list_ducklake_tables()
+```
+
+## Register Parquet files in place
+
+If your data is already in Parquet, `add_data_files()` records the files in
+the lake where they are: no copy, no rewrite, and nothing collected into R.
+A vector of files is registered atomically in one snapshot, which makes
+this the fast migration path for a folder of Parquet extracts. The target
+table can already exist with a compatible schema, or `create = TRUE`
+creates it from the Parquet schema. The lake takes ownership of the files,
+and later compaction may rewrite or delete them.
+
+```{r add_data_files, eval=FALSE}
+add_data_files(
+  "readings",
+  c("extracts/jan.parquet", "extracts/feb.parquet"),
+  create = TRUE
+)
+
+# See which files back a table
+list_ducklake_files("readings")
+```
+
+## Migrate a DuckDB database
+
+A DuckDB database file moves into the lake with one statement: attach it
+read-only and copy every schema and table across. The copy lands as a
+single snapshot.
+
+```{r migrate_duckdb}
+legacy_db <- file.path(vignette_temp_dir, "legacy.duckdb")
+legacy <- DBI::dbConnect(duckdb::duckdb(dbdir = legacy_db))
+DBI::dbWriteTable(
+  legacy, "sites",
+  data.frame(site_id = 1:3, country = c("US", "DE", "JP"))
+)
+DBI::dbDisconnect(legacy, shutdown = TRUE)
+
+conn <- get_ducklake_connection()
+DBI::dbExecute(conn, sprintf("ATTACH '%s' AS legacy (READ_ONLY);", legacy_db))
+DBI::dbExecute(conn, "COPY FROM DATABASE legacy TO loading_lake;")
+DBI::dbExecute(conn, "DETACH legacy;")
+
+get_ducklake_table("sites") |> collect()
+```
+
+Types DuckLake does not support (`ENUM`, `UNION`, `VARINT`, fixed-size
+arrays) need converting first; the DuckLake documentation has a migration
+script for those cases:
+<https://ducklake.select/docs/stable/duckdb/migrations/duckdb_to_ducklake>.
+
+## Exchange data with Iceberg
+
+With DuckDB's iceberg extension attached to an Iceberg REST catalog,
+`COPY FROM DATABASE` moves tables in either direction. Copying into Iceberg
+needs the schemas to exist there first, and the copy adds tables rather
+than replacing them.
+
+```{r iceberg, eval=FALSE}
+DBI::dbExecute(conn, "INSTALL iceberg; LOAD iceberg;")
+DBI::dbExecute(conn, "
+  ATTACH '' AS iceberg_catalog (
+    TYPE iceberg,
+    CLIENT_ID 'admin',
+    CLIENT_SECRET 'password',
+    ENDPOINT 'http://iceberg.example.org:8181'
+  );
+")
+
+# Lake to Iceberg
+DBI::dbExecute(conn, "COPY FROM DATABASE loading_lake TO iceberg_catalog;")
+
+# Iceberg to lake: the data itself, or only the metadata, so that Iceberg
+# tables read as lake tables where they are
+DBI::dbExecute(conn, "COPY FROM DATABASE iceberg_catalog TO loading_lake;")
+DBI::dbExecute(conn, "CALL iceberg_to_ducklake('iceberg_catalog', 'loading_lake');")
+```
+
+```{r cleanup}
+detach_ducklake("loading_lake")
+```

--- a/vignettes/modifying-tables.Rmd
+++ b/vignettes/modifying-tables.Rmd
@@ -55,7 +55,7 @@ Good news first: **every committed change to a DuckLake table creates a
 snapshot**. Whether you use `rows_insert()`, `replace_table()`, or raw SQL,
 DuckLake records what changed and you can time-travel back to any earlier
 state. (Earlier versions of this vignette said the `rows_*` functions skip
-versioning -- that is not true in DuckLake v1.0.) The choice between the
+versioning. That is not true in DuckLake v1.0.) The choice between the
 styles is about *what kind of change* you are making, not about whether it is
 audited.
 
@@ -188,7 +188,7 @@ that the in-place functions above exist.
 Whichever style you use, wrap *related* modifications in
 `with_transaction()`. All changes inside the transaction become **one**
 snapshot, and you can attach an author and commit message for the audit
-trail -- valuable in any setting and essential for GxP/21 CFR Part 11 work:
+trail, valuable in any setting and essential for GxP/21 CFR Part 11 work:
 
 ```r
 with_transaction({
@@ -222,7 +222,7 @@ with_transaction(
 ```
 
 **Insert** new records by key. The new rows are appended in a single SQL
-statement -- the existing rows are never read into R:
+statement, and the existing rows are never read into R:
 
 ```{r rows-insert}
 new_cars <- data.frame(
@@ -257,7 +257,7 @@ get_ducklake_table("fleet") |> collect()
 ```
 
 Each call above created its own snapshot. To record an author and commit
-message -- or to make several row operations land as **one** snapshot -- wrap
+message, or to make several row operations land as **one** snapshot, wrap
 them in `with_transaction()`:
 
 ```{r rows-transaction}
@@ -345,7 +345,7 @@ list_table_snapshots("cars")
 Derived columns no longer need `replace_table()`. Declare the column with
 `add_table_column()` (instant, metadata-only), then fill it with a
 `mutate()` pipeline through `ducklake_exec()`, which runs as an in-database
-UPDATE -- nothing is collected into R:
+UPDATE. Nothing is collected into R:
 
 ```{r add-columns}
 with_transaction({
@@ -369,10 +369,19 @@ get_ducklake_table("cars") |>
   select(hp, cyl, hp_per_cyl, high_performance)
 ```
 
+To see the statement a pipeline would run before committing to it, end the
+pipeline with `show_ducklake_query()` instead of `ducklake_exec()`:
+
+```{r preview-update}
+get_ducklake_table("cars") |>
+  mutate(hp_per_cyl = round(hp_per_cyl, 1)) |>
+  show_ducklake_query()
+```
+
 ### Reshaping the schema in place
 
 The rest of the schema evolution family works the same way. Widen a type,
-rename a column, drop one -- each change is instant, and earlier snapshots
+rename a column, or drop one. Each change is instant, and earlier snapshots
 keep the earlier shape:
 
 ```{r schema-evolution}

--- a/vignettes/views-comments-labels.Rmd
+++ b/vignettes/views-comments-labels.Rmd
@@ -1,0 +1,159 @@
+---
+title: "Views, Comments, and Labels"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Views, Comments, and Labels}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+# Evaluate chunks only where the ducklake DuckDB extension is already
+# installed. The probe never downloads anything, so building this vignette
+# needs no network access.
+ducklake_available <- ducklake::ducklake_extension_available()
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = ducklake_available
+)
+# Use a unique temp directory for this vignette to avoid conflicts during R CMD check
+vignette_temp_dir <- file.path(tempdir(), "views_vignette")
+dir.create(vignette_temp_dir, showWarnings = FALSE, recursive = TRUE)
+knitr::opts_knit$set(root.dir = vignette_temp_dir)
+```
+
+```{r setup, message=FALSE}
+library(ducklake)
+library(dplyr)
+
+attach_ducklake("views_lake", lake_path = vignette_temp_dir)
+
+with_transaction(
+  create_table(mtcars, "cars"),
+  author = "Data Engineer",
+  commit_message = "Add the Motor Trend car data"
+)
+```
+
+Tables hold data. A lake also holds three kinds of things about the data:
+views, which store a query; comments, which document a table or a column;
+and variable labels, which the lake stores as comments. All three live in
+the catalog, so they travel with the lake and every client of it can read
+them.
+
+## Views
+
+A view is a stored query. Reading it runs the query against the tables as
+they are now, so a view is never stale. `create_view()` takes a dplyr
+pipeline built on lake tables and stores its SQL. Like any change to the
+lake, it can be committed with an author and a message:
+
+```{r create_view}
+with_transaction(
+  get_ducklake_table("cars") |>
+    filter(mpg > 25) |>
+    select(mpg, cyl, wt) |>
+    create_view("v_efficient_cars"),
+  author = "Data Engineer",
+  commit_message = "Define the efficient cars everyone reports on"
+)
+
+get_ducklake_table("v_efficient_cars") |> collect()
+```
+
+`get_ducklake_table()` reads views and tables alike, and further verbs
+pipe onto a view as they would onto a table:
+
+```{r view_verbs}
+get_ducklake_table("v_efficient_cars") |>
+  count(cyl)
+```
+
+Views are versioned. Creating, replacing, or dropping one is a snapshot in
+the lake's history, like any change to a table:
+
+```{r view_snapshots}
+list_table_snapshots("v_efficient_cars")
+```
+
+### When a view is the right tool
+
+Reach for a view when the logic belongs to the lake rather than to you: a
+team's shared definition of an analysis population, a filter every report
+must apply, or a derived layer that is cheap enough to compute on read and
+so need not be stored. Every client sees the same definition, whether it
+connects from R, Python, or plain SQL, and a change to the definition is
+recorded in the snapshot history.
+
+Two cases call for something else. An exploratory pipeline that only you
+use is better kept in your R script under version control, where it can
+change freely without adding snapshots to a shared lake. And a result that
+should be materialized, because it is expensive to compute or because
+downstream users need a fixed dataset, belongs in a table: `create_table()`
+or `replace_table()` on the same pipeline.
+
+Drop a view when its logic is no longer needed:
+
+```{r drop_view}
+drop_view("v_efficient_cars")
+```
+
+For logic a view cannot hold, such as a parameterized SQL macro, DuckDB SQL
+is the escape hatch:
+`DBI::dbExecute(get_ducklake_connection(), "CREATE MACRO ...")`.
+
+## Table and column comments
+
+Comments live in the catalog, so the documentation travels with the data
+instead of in a sidecar file:
+
+```{r comments}
+set_table_comment("cars", "Motor Trend road tests of 1973-74 models")
+set_column_comments(
+  "cars",
+  mpg = "Miles per US gallon",
+  wt = "Weight (1000 lbs)"
+)
+
+get_table_comments("cars")
+```
+
+## Variable labels
+
+If your data carries variable labels, they survive the lake.
+`create_table()` stores each column's `label` attribute as a column
+comment, and `collect()` puts the attribute back, so label-aware tools such
+as gtsummary and gt behave as if the data never left R. Data imported with
+haven from SAS, SPSS, or Stata arrives with these labels already. For a
+data frame built in R, the labelled package sets them:
+
+```{r labels, eval = ducklake_available && requireNamespace("labelled", quietly = TRUE)}
+library(labelled)
+
+df_visits <- data.frame(subject = c("S1", "S2"), sbp = c(128, 141)) |>
+  set_variable_labels(
+    subject = "Subject identifier",
+    sbp = "Systolic blood pressure (mmHg)"
+  )
+
+with_transaction(
+  create_table(df_visits, "visits"),
+  author = "Data Engineer",
+  commit_message = "Add the visit measurements"
+)
+
+df_collected <- get_ducklake_table("visits") |> collect()
+var_label(df_collected)
+```
+
+The same round trip works without labelled: a label is the `label`
+attribute of a column, `attr(df_visits$sbp, "label") <- "..."` sets it,
+and `get_table_comments("visits")` shows what was stored. Labels also
+follow columns through pipelines. A table derived with `create_table()`
+from a lake table keeps the comments of the columns it selects, so a
+silver or gold layer stays labelled without any extra step.
+
+```{r cleanup}
+detach_ducklake("views_lake")
+```


### PR DESCRIPTION
Addresses the review comments on the Getting Started article.

## Docs

- Getting Started is one short session: install, attach, add a table, read it, change it, see its history, detach. It explains why calls sit inside `with_transaction()`, when braces are needed, and what `commit_extra_info` is for. `collect()` is described as returning a tibble.
- New article Loading Data: data frames, files, URLs, pipelines, in-database derivation, schemas, `add_data_files()`, DuckDB migration, and Iceberg.
- New article Views, Comments, and Labels: views are catalog-stored and versioned, when to use one versus a git-tracked script, comments, and labels through `labelled::set_variable_labels()`. labelled is added to Suggests.
- Leftover recipes moved to Choosing a Deployment (sorting and partitioning) and Modifying Tables (`show_ducklake_query()`); recipes that duplicated other articles became links. No dash constructions remain in the touched articles.

## Package

- `begin_transaction()` is silent. `commit_transaction()` and `with_transaction()` print one line naming the snapshot, for example `Committed snapshot 2 (Data Engineer): Add fuel efficiency in km/L`. A transaction that changed nothing says so. `restore_table_version()` no longer prints a second confirmation after the commit line.
- Limitation, recorded in the roxygen and in CLAUDE.md: the id is the lake's newest snapshot right after `COMMIT`, so with concurrent writers it can belong to a commit that landed just after.

## Checks

- 257 tests pass, none skipped, with `DUCKDB_R_HOME` set.
- `R CMD check --no-manual`: 0 errors, 0 warnings, 0 notes.
- Touched vignettes rendered and read; `pkgdown::check_pkgdown()` and spelling are clean.
