### PR TITLE
Clean up docs

### DIFF
--- a/vignettes/clinical-trial-datalake.Rmd
+++ b/vignettes/clinical-trial-datalake.Rmd
@@ -185,7 +185,7 @@ get_ducklake_table("dm") |>
 Notice the message when the bronze table was created: SDTM datasets carry
 CDISC variable labels as `label` attributes, and `create_table()` stored
 them in the lake as column comments. The labels are now part of the
-catalog itself -- queryable from R, Python, or SQL, and available as
+catalog itself, queryable from R, Python, or SQL, and available as
 context for AI tools reading the lake:
 
 ```{r dm-labels}
@@ -193,8 +193,8 @@ get_table_comments("dm_raw") |> head()
 ```
 
 They also come back on the way out. `collect()` reattaches stored
-comments as `label` attributes, so label-aware tools downstream --
-gtsummary and gt table headers, labelled-based workflows -- behave as if
+comments as `label` attributes, so label-aware tools downstream, such as
+gtsummary and gt table headers and labelled-based workflows, behave as if
 the data had never left R:
 
 ```{r dm-labels-collect}
@@ -501,7 +501,7 @@ with_transaction(
 )
 
 # Variables carried over from DM kept their SDTM labels automatically.
-# Derived variables are new, so label them now -- the ADaM way, but stored
+# Derived variables are new, so label them now: the ADaM way, but stored
 # in the catalog rather than a spec sidecar
 set_column_comments(
   "adsl",
@@ -1009,7 +1009,7 @@ with_transaction(
 
 Both operations create snapshots you can time-travel back to and include in
 your regulatory audit trail, with the author and commit message recorded by
-`with_transaction()` -- the pattern to keep for GxP/21 CFR Part 11 work.
+`with_transaction()`. That is the pattern to keep for GxP/21 CFR Part 11 work.
 
 #### Iterative Development with Full Audit Trail
 
@@ -1235,7 +1235,7 @@ audit_export
 DuckLake v1.0 enables **data inlining** by default: small modifications
 (inserts, deletes, updates affecting fewer than 10 rows) are stored directly in
 the catalog database rather than writing individual Parquet files. This is a
-pure storage optimisation — it does not affect ACID compliance, versioning, time
+pure storage optimization. It does not affect ACID compliance, versioning, time
 travel, or the audit trail. Clinical trial batch loads (full SDTM/ADaM domains)
 exceed the threshold and go directly to Parquet as usual.
 

--- a/vignettes/data-inlining.Rmd
+++ b/vignettes/data-inlining.Rmd
@@ -58,8 +58,8 @@ attach_ducklake("sensor_lake", lake_path = vignette_temp_dir)
 
 ## Small writes are automatically inlined
 
-Let's create a small sensor-readings table. Because the data has only 3 rows —
-well below the default inlining threshold of 10 — DuckLake stores it directly
+Start with a small sensor-readings table. The data has only 3 rows, well
+below the default inlining threshold of 10, so DuckLake stores it directly
 in the catalog instead of writing a Parquet file.
 
 ```{r create-table}
@@ -79,7 +79,7 @@ with_transaction(
 )
 ```
 
-No Parquet files were created — all data is inlined in the catalog:
+No Parquet files were created. All of the data is inlined in the catalog:
 
 ```{r verify-no-parquet}
 conn <- get_ducklake_connection()
@@ -137,11 +137,11 @@ get_ducklake_table("readings") |> collect()
 
 ## Large writes bypass inlining automatically
 
-When a write exceeds the threshold, DuckLake writes directly to Parquet — no
-configuration needed:
+When a write exceeds the threshold, DuckLake writes directly to Parquet, with
+no configuration needed:
 
 ```{r large-insert}
-# 50 rows — well above the default threshold of 10
+# 50 rows, well above the default threshold of 10
 large_batch <- data.frame(
   sensor_id = 101:150,
   temperature = rnorm(50, mean = 22, sd = 1),
@@ -269,7 +269,7 @@ if (nrow(snapshots) > 0) {
 
 | Workload | Recommendation |
 |---|---|
-| Streaming / IoT sensors | Increase threshold (e.g., 50–100) |
+| Streaming / IoT sensors | Increase threshold (e.g., 50 to 100) |
 | Periodic large batch loads | Default (10) is fine |
 | Single-row corrections | Default handles it automatically |
 | Append-only bulk ETL | Consider disabling (`limit = 0`) |

--- a/vignettes/modifying-tables.Rmd
+++ b/vignettes/modifying-tables.Rmd
@@ -59,7 +59,7 @@ versioning. That is not true in DuckLake v1.0.) The choice between the
 styles is about *what kind of change* you are making, not about whether it is
 audited.
 
-One distinction matters before anything else: dplyr joins **read** --
+One distinction matters before anything else: dplyr joins **read**.
 `left_join()` and friends combine tables into a new result and never touch
 the stored data. Everything else in this table **writes**.
 

--- a/vignettes/storage-and-backups.Rmd
+++ b/vignettes/storage-and-backups.Rmd
@@ -44,7 +44,7 @@ DuckLake separates data management into two distinct components:
 
 1. **Catalog (Metadata)**: A database that stores all metadata about your tables, snapshots, transactions, and data file locations. By default this is a DuckDB file, but DuckLake also supports PostgreSQL, SQLite, or MySQL as catalog backends (see `?attach_ducklake`). The catalog is typically small but critically important.
 
-2. **Storage (Data Files)**: A directory containing immutable Parquet files that hold your actual data. DuckLake never modifies existing files—it only creates new ones.
+2. **Storage (Data Files)**: A directory containing immutable Parquet files that hold your actual data. DuckLake never modifies an existing file. It only creates new ones.
 
 This separation provides several benefits:
 
@@ -113,7 +113,7 @@ create_storage_secret(
 )
 
 # Or let the AWS credential chain find them (env vars, profiles,
-# instance metadata) -- no keys in code
+# instance metadata), so no keys sit in code
 create_storage_secret("s3", provider = "credential_chain")
 
 # Then attach. With the default duckdb backend the catalog file must stay
@@ -226,7 +226,7 @@ The key insight is that **DuckLake never modifies existing Parquet files**. Each
 
 ### Backing Up the Catalog
 
-The catalog is the most critical component—it maps snapshots to data files. Regular backups are essential.
+The catalog is the most critical component: it maps snapshots to data files. Regular backups are essential.
 
 #### Copying the Catalog
 
@@ -419,7 +419,7 @@ cleanup_old_files(cleanup_all = TRUE)
 # Rewrite data files whose rows have mostly been deleted
 rewrite_data_files(delete_threshold = 0.5)
 
-# Remove untracked files from the data path -- always dry-run this one first
+# Remove untracked files from the data path. Always dry-run this one first
 delete_orphaned_files(dry_run = TRUE, cleanup_all = TRUE)
 ```
 

--- a/vignettes/time-travel.Rmd
+++ b/vignettes/time-travel.Rmd
@@ -258,9 +258,9 @@ a custom `commit_message` if the default ("Restored cars to snapshot 2")
 isn't descriptive enough for your audit trail.
 
 Nothing is lost in a restore: the rollback happens *forward*, as a new
-snapshot with its own author and commit message, so the full
-history — including the states after the restore point — remains available
-for time travel. That also means a restore is itself reversible with another
+snapshot with its own author and commit message, so the full history,
+including the states after the restore point, remains available for time
+travel. That also means a restore is itself reversible with another
 `restore_table_version()` call:
 
 ```{r after-restore}
@@ -269,8 +269,8 @@ list_table_snapshots("cars")
 
 ## Pinning a Whole Session to a Snapshot
 
-The queries above travel one table at a time. To freeze *everything* — say,
-to re-run a report exactly as it stood at a submission milestone — attach
+The queries above travel one table at a time. To freeze *everything*, say
+to re-run a report exactly as it stood at a submission milestone, attach
 the lake pinned to a snapshot:
 
 ```{r pinned-attach, eval=FALSE}

--- a/vignettes/visualizing-your-lake.Rmd
+++ b/vignettes/visualizing-your-lake.Rmd
@@ -203,9 +203,9 @@ delete-file share mean it is time for the compaction tools covered in
 With two tables in the lake, we can step back and look at everything at
 once. Calling `plot_snapshots()` without a table name switches to a swimlane
 view: one row per table, one point per snapshot, with recently active tables
-at the top. It answers a different question than the single-table timeline
--- not "what happened to this table" but "which tables are active, and what
-kind of churn does each one see":
+at the top. Where the single-table timeline shows what happened to one
+table, the swimlane shows which tables are active and what kind of churn
+each one sees:
 
 ```{r plot-lake}
 plot_snapshots()


### PR DESCRIPTION
Sweeps the remaining dash constructions out of the vignettes, following the rewrite in #56.

- Eighteen spans in Clinical Trial Data Lake, Data Inlining, Storage and Backups, Time Travel, Visualizing Your Lake, and Modifying Tables become commas, colons, or two sentences. Three of them are code comments inside chunks.
- Two sentences were reworded beyond punctuation: the "Let's create" opener in Data Inlining and the "not X but Y" contrast in Visualizing Your Lake.
- No em dash, en dash, or double hyphen remains in any vignette. The chunk code parses and the spell check is clean. Prose-only changes, so nothing was re-rendered.
