### PR TITLE
Make the extension download a first-use event, not a documented step

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -29,9 +29,10 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
-      # duckdb >= 1.5.2 keeps extensions in a per-process tempdir unless given
-      # a persistent home; without this, the pre-installed extension is invisible
-      # to the check's subprocesses and examples/vignettes silently skip.
+      # A non-interactive duckdb session keeps extensions in a per-process
+      # tempdir unless given a home; without this, the pre-installed extension
+      # is invisible to the check's subprocesses and examples/vignettes
+      # silently skip.
       DUCKDB_R_HOME: ~/.duckdb-ci
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,13 @@
 - **`set_snapshot_metadata()` fills blanks only** unless `overwrite = TRUE`;
   at-commit metadata is the audited path, and an overwrite is an edit to
   the audit trail.
-- **Minimum duckdb is 1.5.2**, the release that ships DuckLake 1.0. The
-  extension for 1.5.1 wrote 0.4-format catalogs; `automatic_migration`
-  upgrades them.
+- **Minimum duckdb is 1.5.5** (raised from 1.5.2 on 2026-09-07). DuckLake
+  1.0 ships with DuckDB 1.5.2 (the 1.5.1 extension wrote 0.4-format
+  catalogs; `automatic_migration` upgrades them); 1.5.5 is where duckdb-r
+  settled its extension storage policy and API (`duckdb_storage_status()`,
+  `duckdb(home = )`), which `ducklake_extension_available()` uses. The
+  1.5.4.x releases carried a package-library extension cache that upstream
+  withdrew, and are excluded on purpose.
 - **`CHECKPOINT` expires and deletes nothing without a policy**
   (`expire_older_than`, `delete_older_than`); verified 2026-09-04.
 - **Schema-qualified names go through `dbplyr::tbl_sql()` with a quoted
@@ -67,10 +71,26 @@
 - **Windows (`windows_amd64_mingw`, what duckdb-r uses)**: `sqlite_scanner`,
   `httpfs`, `quack`, and `ducklake` exist; `postgres`, `mysql`, `aws`, and
   `azure` do not (checked 2026-09-04 for v1.5.1 and v1.5.5).
-- **Extension persistence**: duckdb-r 1.5.2+ keeps extensions in a
-  per-session temp directory unless `DUCKDB_R_HOME` (or `duckdb.home`, or
-  an existing `~/.duckdb`) is set; local development and CI set
-  `DUCKDB_R_HOME`.
+- **Extension persistence** (duckdb-r 1.5.5, confirmed 2026-09-07): every
+  new `duckdb()` driver resolves one home root, `home` argument →
+  `duckdb.home` option → `DUCKDB_R_HOME` → existing `~/.duckdb` →
+  interactive one-time offer to create `~/.duckdb` (`askYesNo`, default
+  yes) → per-session tempdir; non-interactive sessions get a throttled
+  message instead. The R client sets `autoinstall_known_extensions =
+  false`, so an explicit `LOAD` never downloads and
+  `load_or_install_extension()` is the package's only install path. Local
+  development and CI set `DUCKDB_R_HOME`.
+- **No load-time extension check or install** (2026-09-07).
+  `install_ducklake()` is optional: `attach_ducklake()` installs on first
+  use after a message, and duckdb's connect-time prompt handles the durable
+  directory. An `.onLoad()`/`.onAttach()` probe would start DuckDB on every
+  `library(ducklake)` (dependency loads and `R CMD check` included) to
+  answer a question the attach path already answers; a load-time download
+  would break CRAN's rule against writing outside the session tempdir
+  without consent; a startup message about the directory would fire in
+  every session for every user without the setting and duplicate duckdb's
+  prompt. `create_ducklake_connection()` deliberately passes no `home`, so
+  that prompt is not suppressed.
 - **Iceberg interop is documented, not wrapped** (2026-09-04): `COPY FROM
   DATABASE lake TO iceberg_catalog` and `iceberg_to_ducklake()` live in
   DuckDB's iceberg extension; `vignette("loading-data")` shows them. This closes the

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     DBI,
     dbplyr (>= 2.5.0),
     dplyr,
-    duckdb (>= 1.5.2)
+    duckdb (>= 1.5.5)
 Suggests:
     admiral,
     askpass,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,28 @@
 # ducklake (development version)
 
+* The ducklake DuckDB extension no longer needs an install step. The code
+  never required one: `attach_ducklake()` has always installed it on first
+  use, after a message naming the directory. The README and the articles
+  now say so, and `install_ducklake()` is documented as the way to download
+  the extension ahead of time (container images, CI, machines that are
+  offline when the lake is attached). A first-use install now also clears
+  the answer `ducklake_extension_available()` cached, so it reports `TRUE`
+  afterwards. The hint that follows an install into a temporary directory
+  did not show on macOS for a first-use install, because the directory
+  does not exist until `INSTALL` creates it and the check only recognized
+  existing paths; it shows now. No load-time check was added: the package
+  neither downloads nor starts DuckDB when it is loaded.
+
+* The minimum duckdb version is now 1.5.5, the release that settled where
+  the R package keeps downloaded extensions: `~/.duckdb` when it exists
+  (duckdb offers to create it the first time it connects in an interactive
+  session), `DUCKDB_R_HOME` or the `duckdb.home` option when set, otherwise
+  a per-session temporary directory (`?duckdb::duckdb_storage`).
+  `ducklake_extension_available()` now opens its probe on the directory
+  duckdb would resolve for a new connection, so it finds an existing
+  `~/.duckdb` without triggering that offer, and the hint printed after an
+  install into a temporary directory describes these options.
+
 * `with_transaction()` and `commit_transaction()` confirm a commit with one
   line naming the snapshot it created, with the author and commit message
   when they were given: "Committed snapshot 3 (Data Engineer): Add the

--- a/R/attach_ducklake.R
+++ b/R/attach_ducklake.R
@@ -9,6 +9,15 @@
 #' which enables concurrent multi-client access.
 #' See \url{https://ducklake.select/docs/stable/duckdb/usage/choosing_a_catalog_database}.
 #'
+#' The ducklake extension, and the extension for a non-DuckDB backend, are
+#' loaded on each attach and downloaded the first time they are needed; a
+#' message names the extension and the directory before any download. Where
+#' that directory is depends on duckdb (see `?duckdb::duckdb_storage`): in an
+#' interactive session duckdb offers to create `~/.duckdb` the first time it
+#' connects, and with that the download happens once per machine. To fetch
+#' the extensions ahead of time, for a container image or a machine that is
+#' offline when the lake is attached, use [install_ducklake()].
+#'
 #' @param ducklake_name Name for the ducklake, used as the database alias in DuckDB
 #' @param lake_path Directory where the Parquet data files are stored
 #'   (DuckLake's `DATA_PATH`). May be a local directory, created if it does

--- a/R/availability.R
+++ b/R/availability.R
@@ -1,27 +1,34 @@
 #' Is the ducklake DuckDB extension usable?
 #'
 #' Reports whether the `ducklake` DuckDB extension is already installed and
-#' can be loaded. The check opens a throwaway in-memory DuckDB connection with
-#' automatic extension installation turned off, so it never downloads anything
-#' and never writes to the extension cache in your home directory. It also
-#' leaves the package's own connection untouched.
+#' can be loaded. The check opens a throwaway in-memory DuckDB connection,
+#' asks DuckDB's extension catalog whether the extension is installed, and
+#' loads it only if so. Reading the catalog cannot download anything, and
+#' loading an installed extension does not reach the network, so the probe
+#' never downloads and never writes to the extension directory. The
+#' connection is opened on the directory duckdb would resolve for a new
+#' connection, so an existing `~/.duckdb` is found, and the offer duckdb
+#' makes to create one is not triggered. The package's own connection is
+#' left untouched.
 #'
 #' Use it to guard code that should degrade gracefully when the extension is
 #' absent: examples, vignettes, tests, and conditional branches in scripts.
-#' The package's own examples are gated on it. To install the extension, call
-#' [install_ducklake()].
+#' The package's own examples are gated on it. There is no need to call it
+#' before [attach_ducklake()], which installs the extension the first time it
+#' is needed; [install_ducklake()] downloads it ahead of time.
 #'
-#' A `FALSE` on a machine where [install_ducklake()] has already run usually
-#' means the extension went into a temporary directory: from duckdb 1.5.2
-#' on, extensions are kept under a "home" directory that defaults to a
-#' per-session temporary directory unless `DUCKDB_R_HOME` (or the
-#' `duckdb.home` option, or an existing `~/.duckdb`) points somewhere
-#' durable. See [install_ducklake()].
+#' A `FALSE` on a machine where the extension was installed earlier usually
+#' means it went into a temporary directory. duckdb keeps extensions under a
+#' "home" directory: the `duckdb.home` option or `DUCKDB_R_HOME` when set,
+#' otherwise `~/.duckdb` when it exists (in an interactive session duckdb
+#' offers to create it the first time it connects), otherwise a per-session
+#' temporary directory. See `?duckdb::duckdb_storage`.
 #'
 #' The result is cached for the rest of the session, since spinning up DuckDB
 #' to re-answer the same question is wasteful when dozens of examples ask it.
-#' [install_ducklake()] clears the cache, so a `FALSE` answer becomes `TRUE`
-#' as soon as you install.
+#' [install_ducklake()] and a first-use install by [attach_ducklake()] clear
+#' the cache, so a `FALSE` answer becomes `TRUE` as soon as the extension is
+#' there.
 #'
 #' @returns A single logical: `TRUE` when the extension loads, `FALSE`
 #'   otherwise (including when a connection cannot be opened).
@@ -32,7 +39,7 @@
 #' if (ducklake_extension_available()) {
 #'   message("ducklake extension is ready to use")
 #' } else {
-#'   message("run install_ducklake() first")
+#'   message("attach_ducklake() will download it on first use")
 #' }
 ducklake_extension_available <- function() {
   cached <- .ducklake_env$ext_available
@@ -42,10 +49,14 @@ ducklake_extension_available <- function() {
 
   ok <- tryCatch(
     {
-      con <- DBI::dbConnect(duckdb::duckdb())
+      # Open the probe on the home directory duckdb would resolve for a new
+      # connection. Given a `home`, duckdb() neither offers to create
+      # ~/.duckdb nor creates anything itself (see ?duckdb::duckdb_storage).
+      home <- storage_home_root(duckdb::duckdb_storage_status())
+      con <- DBI::dbConnect(duckdb::duckdb(home = home))
       on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
-      # Ask the catalog rather than attempting LOAD: a failed LOAD can trigger
-      # DuckDB's automatic install, which downloads into ~/.duckdb/. Reading
+      # Ask the catalog rather than attempting LOAD, so the answer does not
+      # depend on the connection's autoinstall setting: reading
       # duckdb_extensions() cannot download anything.
       installed <- DBI::dbGetQuery(
         con,
@@ -64,6 +75,23 @@ ducklake_extension_available <- function() {
 
   .ducklake_env$ext_available <- ok
   ok
+}
+
+#' The home directory duckdb would use for a new connection
+#'
+#' @param status The data frame from [duckdb::duckdb_storage_status()]: one
+#'   row per kind of on-disk state, with the `directory` for `"extensions"`
+#'   at `<home>/extensions`.
+#' @returns The `<home>` path as a string.
+#' @noRd
+storage_home_root <- function(status) {
+  dir <- status$directory[status$kind == "extensions"]
+  if (length(dir) != 1 || is.na(dir) || !nzchar(dir)) {
+    cli::cli_abort(
+      "Could not read the extension directory from {.fn duckdb::duckdb_storage_status}."
+    )
+  }
+  dirname(dir)
 }
 
 #' Forget a cached extension-availability answer

--- a/R/install_ducklake.R
+++ b/R/install_ducklake.R
@@ -1,24 +1,27 @@
-#' Install the ducklake extension to duckdb
+#' Download the ducklake extension ahead of time
 #'
-#' Installs the ducklake DuckDB extension and optionally the extensions for
-#' alternative catalog backends (postgres, sqlite, mysql). Needs to run once
-#' per DuckDB version, provided DuckDB's extension directory survives the
-#' session (see Details).
+#' [attach_ducklake()] installs the ducklake DuckDB extension the first time
+#' it is needed, so most sessions never call this function. It downloads the
+#' extension now, and optionally the extensions for the other catalog
+#' backends (postgres, sqlite, mysql), for the cases where the download has
+#' to happen before a lake is attached: baking a container image, a CI setup
+#' step, or a machine that is offline at attach time.
 #'
 #' @param backend Optional character vector of backends to install. The ducklake
 #'   extension is always installed. Pass `"postgres"`, `"sqlite"`, and/or
 #'   `"mysql"` to install the corresponding backend extensions.
 #'
 #' @details
-#' Where the extension lands depends on the duckdb R package. From duckdb
-#' 1.5.2 on, extensions live under a "home" directory that defaults to a
-#' per-session temporary directory unless something durable is configured:
-#' the `DUCKDB_R_HOME` environment variable (set it in `~/.Renviron` so every
-#' session sees it), the `duckdb.home` option, or an existing `~/.duckdb`
-#' directory. With the temporary default, the extension is gone when R
-#' exits and the next session downloads it again. `install_ducklake()`
-#' reports the directory it installed into and says so when that directory
-#' is temporary.
+#' Where the extension lands is decided by the duckdb R package (see
+#' `?duckdb::duckdb_storage`). Extensions live under a "home" directory: the
+#' `duckdb.home` option or `DUCKDB_R_HOME` when set, otherwise `~/.duckdb`
+#' when it exists (in an interactive session duckdb offers to create it the
+#' first time it connects), otherwise a per-session temporary directory.
+#' With the temporary directory the extension is gone when R exits and the
+#' next session downloads it again. `install_ducklake()` reports the
+#' directory it installed into and says so when that directory is temporary.
+#' For scripts and CI, set `DUCKDB_R_HOME` in `~/.Renviron` or the job's
+#' environment to a directory that survives the session.
 #'
 #' @note On Windows the `postgres` and `mysql` extensions are not available
 #'   (MinGW toolchain). See [attach_ducklake()] for details.

--- a/R/storage_secrets.R
+++ b/R/storage_secrets.R
@@ -23,13 +23,13 @@
 #'   and dropped individually; unnamed ones act as the default for their
 #'   type.
 #' @param persistent If `TRUE`, the secret is written (unencrypted) to
-#'   DuckDB's secret directory and survives the session. Where that is
-#'   depends on the duckdb R package: from 1.5.2 on it sits under the same
-#'   "home" directory as extensions (`DUCKDB_R_HOME`, the `duckdb.home`
-#'   option, or `~/.duckdb`; see [install_ducklake()]), and with the
-#'   temporary default the secret is lost with the session anyway. The
-#'   default `FALSE` keeps it in memory only, which is the right choice for
-#'   credentials supplied from a vault or environment variable.
+#'   DuckDB's secret directory and survives the session. That directory sits
+#'   under the same "home" directory as extensions (`~/.duckdb` when it
+#'   exists, or `DUCKDB_R_HOME` / the `duckdb.home` option; see
+#'   `?duckdb::duckdb_storage`), and with the temporary default the secret
+#'   is lost with the session anyway. The default `FALSE` keeps it in memory
+#'   only, which is the right choice for credentials supplied from a vault
+#'   or environment variable.
 #'
 #' @details
 #' The httpfs extension (or the azure extension for `type = "azure"`) is

--- a/R/utils.R
+++ b/R/utils.R
@@ -14,9 +14,12 @@ db_execute <- function(sql, conn = get_ducklake_connection()) {
 
 #' Load a DuckDB extension, installing it first if needed
 #'
-#' Says so before installing: a download into DuckDB's extension directory
-#' should never be a silent side effect of calling an unrelated function.
-#' The message names the directory and warns when it is a temporary one.
+#' This is the package's one install path: the duckdb R client turns
+#' DuckDB's automatic extension install off, so a failed `LOAD` never
+#' downloads by itself. Says so before installing: a download into DuckDB's
+#' extension directory should never be a silent side effect of calling an
+#' unrelated function. The message names the directory and warns when it is
+#' a temporary one.
 #'
 #' @param ext Extension name.
 #' @param conn A DBI connection; defaults to the shared ducklake connection.
@@ -33,6 +36,9 @@ load_or_install_extension <- function(ext, conn = get_ducklake_connection()) {
       ))
       db_execute(sprintf("INSTALL %s;", ext), conn = conn)
       db_execute(sprintf("LOAD %s;", ext), conn = conn)
+      if (identical(ext, "ducklake")) {
+        reset_extension_available_cache()
+      }
     }
   )
   invisible(NULL)
@@ -320,11 +326,13 @@ extension_directory <- function(conn = get_ducklake_connection()) {
 
 #' cli bullets explaining how to keep extensions between sessions
 #'
-#' duckdb 1.5.2 and later resolve a "home" directory for extensions that
-#' defaults to a per-session temporary directory unless `DUCKDB_R_HOME`
-#' (or `options(duckdb.home = )`, or an existing `~/.duckdb`) points at
-#' somewhere durable. An install into a temporary directory is repeated on
-#' every session, so say so.
+#' duckdb resolves a "home" directory for extensions (`duckdb.home` option,
+#' `DUCKDB_R_HOME`, an existing `~/.duckdb`, else a per-session temporary
+#' directory; see `?duckdb::duckdb_storage`). An install into the temporary
+#' directory is repeated on every session, so say so. The check looks at the
+#' directory the connection in use reports rather than at
+#' `duckdb_storage_status()`, because a user-supplied connection may have
+#' been created with its own `home`.
 #'
 #' @param dir The extension directory, as reported by DuckDB.
 #' @returns A named character vector of bullets, empty when the directory
@@ -334,16 +342,20 @@ extension_persistence_hint <- function(dir) {
   if (length(dir) != 1 || is.na(dir) || !nzchar(dir)) {
     return(character())
   }
-  is_temp <- startsWith(
-    normalizePath(dir, mustWork = FALSE),
-    normalizePath(tempdir(), mustWork = FALSE)
-  )
+  # normalizePath() leaves a path that does not exist yet untouched (DuckDB
+  # creates the directory on INSTALL), and on macOS tempdir() is a symlinked
+  # path with a doubled slash, so compare raw and resolved forms of both
+  clean <- function(p) {
+    p <- c(p, normalizePath(p, winslash = "/", mustWork = FALSE))
+    gsub("/{2,}", "/", gsub("\\\\", "/", p))
+  }
+  is_temp <- any(outer(clean(dir), clean(tempdir()), startsWith))
   if (!is_temp) {
     return(character())
   }
   c(
     "!" = "This directory is temporary: the extension is gone when the R session ends.",
-    "i" = "To keep extensions between sessions, set {.envvar DUCKDB_R_HOME} to a durable directory (for example in {.file ~/.Renviron}) before duckdb is loaded."
+    "i" = "To keep extensions between sessions, create {.path ~/.duckdb} once (duckdb offers to create it the first time it connects in an interactive session), or set {.envvar DUCKDB_R_HOME} in {.file ~/.Renviron} for scripts and CI. See {.topic duckdb::duckdb_storage}."
   )
 }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -58,17 +58,20 @@ pak::pak("tgerke/ducklake-r")
 ```
 
 ducklake requires the [duckdb](https://r.duckdb.org) R package version
-1.5.2 or newer: DuckDB 1.5.2 is the release that ships the stable
-[DuckLake 1.0 specification](https://ducklake.select/docs/stable/specification/introduction).
-The Quack remote-access features need DuckDB 1.5.3 or newer, which means
-duckdb 1.5.3 or newer from CRAN.
+1.5.5 or newer. DuckDB 1.5.2 is the release that ships the stable
+[DuckLake 1.0 specification](https://ducklake.select/docs/stable/specification/introduction),
+and duckdb 1.5.5 is where the R package settled how it stores downloaded
+extensions, which ducklake relies on.
 
-DuckLake itself ships as a DuckDB extension that is downloaded on first use.
-Run `install_ducklake()` once, or check whether you already have it with
-`ducklake_extension_available()`. From duckdb 1.5.2 on, extensions live in a
-per-session temporary directory unless you point `DUCKDB_R_HOME` (for
-example in `~/.Renviron`) at a directory of your choice. Do that, and the
-download happens once per machine instead of once per session.
+DuckLake itself ships as a DuckDB extension. `attach_ducklake()` downloads
+it the first time it is needed and says where it put it, so there is no
+install step. In an interactive session, duckdb offers to create
+`~/.duckdb` the first time it connects; say yes and the download happens
+once per machine rather than once per session. Scripts and CI jobs get the
+same by setting `DUCKDB_R_HOME` in `~/.Renviron` or the job's environment.
+`install_ducklake()` fetches the extension ahead of time, for container
+images and machines that are offline when the lake is attached, and
+`ducklake_extension_available()` reports whether it is already there.
 
 ducklake manages its own DuckDB connection, so there is nothing to set up:
 just `attach_ducklake()` and go. If you prefer to supply your own connection
@@ -80,9 +83,6 @@ just `attach_ducklake()` and go. If you prefer to supply your own connection
 ```{r example, message=FALSE}
 library(ducklake)
 library(dplyr)
-
-# Install the ducklake extension (requires duckdb R package >= 1.5.2)
-install_ducklake()
 
 # Create a data lake in a temporary directory
 attach_ducklake("my_data_lake", lake_path = tempdir())
@@ -206,7 +206,7 @@ Check out the [pkgdown site](https://tgerke.github.io/ducklake-r/) for detailed 
 
 - **Versioned data lake**: Every data change automatically tracked with timestamps and metadata
 - **Multi-backend catalogs**: Use DuckDB (default), PostgreSQL, SQLite, or MySQL as the catalog database — enables concurrent multi-client access with PostgreSQL or SQLite ([DuckLake 1.0 spec](https://ducklake.select/docs/stable/specification/introduction))
-- **Remote access over Quack**: Serve a DuckLake to other R sessions over the network and let several people read and write it at once, using DuckDB's Quack protocol (requires DuckDB 1.5.3 or newer)
+- **Remote access over Quack**: Serve a DuckLake to other R sessions over the network and let several people read and write it at once, using DuckDB's Quack protocol
 - **Lightweight snapshots**: Create unlimited snapshots without frequent compacting steps
 - **Medallion architecture**: Bronze/silver/gold layers for data lineage and quality
 - **ACID transactions**: Atomic updates with concurrent access and transactional guarantees over multi-table operations; `set_ducklake_retry()` tunes how DuckLake retries transactions that race with another writer

--- a/README.md
+++ b/README.md
@@ -62,19 +62,22 @@ pak::pak("tgerke/ducklake-r")
 ```
 
 ducklake requires the [duckdb](https://r.duckdb.org) R package version
-1.5.2 or newer: DuckDB 1.5.2 is the release that ships the stable
+1.5.5 or newer. DuckDB 1.5.2 is the release that ships the stable
 [DuckLake 1.0
-specification](https://ducklake.select/docs/stable/specification/introduction).
-The Quack remote-access features need DuckDB 1.5.3 or newer, which means
-duckdb 1.5.3 or newer from CRAN.
+specification](https://ducklake.select/docs/stable/specification/introduction),
+and duckdb 1.5.5 is where the R package settled how it stores downloaded
+extensions, which ducklake relies on.
 
-DuckLake itself ships as a DuckDB extension that is downloaded on first
-use. Run `install_ducklake()` once, or check whether you already have it
-with `ducklake_extension_available()`. From duckdb 1.5.2 on, extensions
-live in a per-session temporary directory unless you point
-`DUCKDB_R_HOME` (for example in `~/.Renviron`) at a directory of your
-choice. Do that, and the download happens once per machine instead of
-once per session.
+DuckLake itself ships as a DuckDB extension. `attach_ducklake()`
+downloads it the first time it is needed and says where it put it, so
+there is no install step. In an interactive session, duckdb offers to
+create `~/.duckdb` the first time it connects; say yes and the download
+happens once per machine rather than once per session. Scripts and CI
+jobs get the same by setting `DUCKDB_R_HOME` in `~/.Renviron` or the
+job’s environment. `install_ducklake()` fetches the extension ahead of
+time, for container images and machines that are offline when the lake
+is attached, and `ducklake_extension_available()` reports whether it is
+already there.
 
 ducklake manages its own DuckDB connection, so there is nothing to set
 up: just `attach_ducklake()` and go. If you prefer to supply your own
@@ -86,9 +89,6 @@ register it with `set_ducklake_connection()`.
 ``` r
 library(ducklake)
 library(dplyr)
-
-# Install the ducklake extension (requires duckdb R package >= 1.5.2)
-install_ducklake()
 
 # Create a data lake in a temporary directory
 attach_ducklake("my_data_lake", lake_path = tempdir())
@@ -146,7 +146,7 @@ get_ducklake_table("gold.vehicle_efficiency") |>
   select(mpg, cyl, efficiency) |>
   head(3)
 #> # A query:  ?? x 3
-#> # Database: DuckDB 1.5.5 [tgerke@Darwin 25.6.0:R 4.5.2//private/var/folders/b7/664jmq55319dcb7y4jdb39zr0000gq/T/Rtmpt7y8Lw/ducklake/ducklake623c4db47890.duckdb]
+#> # Database: DuckDB 1.5.5 [tgerke@Darwin 25.6.0:R 4.5.2//private/var/folders/b7/664jmq55319dcb7y4jdb39zr0000gq/T/Rtmpyfo6Cq/ducklake/ducklake11c574a450c21.duckdb]
 #>     mpg cyl   efficiency
 #>   <dbl> <chr> <chr>     
 #> 1  21   6.0   Medium    
@@ -156,12 +156,12 @@ get_ducklake_table("gold.vehicle_efficiency") |>
 # View complete audit trail across all layers with author and commit messages
 list_table_snapshots()
 #>   snapshot_id       snapshot_time schema_version
-#> 1           0 2026-09-04 23:25:48              0
-#> 2           1 2026-09-04 23:25:48              1
-#> 3           2 2026-09-04 23:25:48              2
-#> 4           3 2026-09-04 23:25:48              3
-#> 5           4 2026-09-04 23:25:48              4
-#> 6           5 2026-09-04 23:25:48              5
+#> 1           0 2026-09-07 18:08:04              0
+#> 2           1 2026-09-07 18:08:04              1
+#> 3           2 2026-09-07 18:08:04              2
+#> 4           3 2026-09-07 18:08:04              3
+#> 5           4 2026-09-07 18:08:04              4
+#> 6           5 2026-09-07 18:08:04              5
 #>                                                                       changes
 #> 1                                                       schemas_created, main
 #> 2                                       schemas_created, bronze, silver, gold
@@ -189,7 +189,7 @@ get_ducklake_table_version("silver.vehicles", version = 3) |>
   select(mpg, cyl, gear) |>
   head(3)
 #> # A query:  ?? x 3
-#> # Database: DuckDB 1.5.5 [tgerke@Darwin 25.6.0:R 4.5.2//private/var/folders/b7/664jmq55319dcb7y4jdb39zr0000gq/T/Rtmpt7y8Lw/ducklake/ducklake623c4db47890.duckdb]
+#> # Database: DuckDB 1.5.5 [tgerke@Darwin 25.6.0:R 4.5.2//private/var/folders/b7/664jmq55319dcb7y4jdb39zr0000gq/T/Rtmpyfo6Cq/ducklake/ducklake11c574a450c21.duckdb]
 #>     mpg cyl    gear
 #>   <dbl> <chr> <dbl>
 #> 1  21   6.0       4
@@ -309,7 +309,7 @@ detailed vignettes:
   spec](https://ducklake.select/docs/stable/specification/introduction))
 - **Remote access over Quack**: Serve a DuckLake to other R sessions
   over the network and let several people read and write it at once,
-  using DuckDB’s Quack protocol (requires DuckDB 1.5.3 or newer)
+  using DuckDB’s Quack protocol
 - **Lightweight snapshots**: Create unlimited snapshots without frequent
   compacting steps
 - **Medallion architecture**: Bronze/silver/gold layers for data lineage

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -55,10 +55,10 @@ reference:
   - title: "Setup and Connection"
     desc: "Initialize and manage DuckLake connections"
     contents:
-    - install_ducklake
-    - ducklake_extension_available
     - attach_ducklake
     - detach_ducklake
+    - install_ducklake
+    - ducklake_extension_available
     - get_ducklake_connection
     - set_ducklake_connection
     - get_ducklake_backend

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -41,7 +41,8 @@ the user's home directory. Tests also call `skip_on_cran()`.
   external infrastructure: a running Quack server, a PostgreSQL or MySQL
   catalog, or a remote URL.
 * Vignettes evaluate their chunks only when the same predicate returns `TRUE`.
-* `install_ducklake()` is the one function that installs the extension, and it
-  only does so when the user calls it. Where the package loads an extension on
-  the user's behalf, it prints a message naming the extension and the
-  destination before any download.
+* Extensions are installed only on the user's behalf and never silently:
+  `attach_ducklake()` installs the extension the first time a lake is
+  attached, and `install_ducklake()` does so ahead of time. Both print a
+  message naming the extension and the destination before any download.
+  Nothing is downloaded at package load or by the availability probe.

--- a/man/attach_ducklake.Rd
+++ b/man/attach_ducklake.Rd
@@ -118,6 +118,15 @@ By default DuckDB is used as the catalog database. Alternative backends
 which enables concurrent multi-client access.
 See \url{https://ducklake.select/docs/stable/duckdb/usage/choosing_a_catalog_database}.
 
+The ducklake extension, and the extension for a non-DuckDB backend, are
+loaded on each attach and downloaded the first time they are needed; a
+message names the extension and the directory before any download. Where
+that directory is depends on duckdb (see \code{?duckdb::duckdb_storage}): in an
+interactive session duckdb offers to create \verb{~/.duckdb} the first time it
+connects, and with that the download happens once per machine. To fetch
+the extensions ahead of time, for a container image or a machine that is
+offline when the lake is attached, use \code{\link[=install_ducklake]{install_ducklake()}}.
+
 For credential management with PostgreSQL or MySQL, consider DuckDB's
 built-in secrets manager instead of embedding credentials in the connection
 string:

--- a/man/create_storage_secret.Rd
+++ b/man/create_storage_secret.Rd
@@ -38,13 +38,13 @@ and dropped individually; unnamed ones act as the default for their
 type.}
 
 \item{persistent}{If \code{TRUE}, the secret is written (unencrypted) to
-DuckDB's secret directory and survives the session. Where that is
-depends on the duckdb R package: from 1.5.2 on it sits under the same
-"home" directory as extensions (\code{DUCKDB_R_HOME}, the \code{duckdb.home}
-option, or \verb{~/.duckdb}; see \code{\link[=install_ducklake]{install_ducklake()}}), and with the
-temporary default the secret is lost with the session anyway. The
-default \code{FALSE} keeps it in memory only, which is the right choice for
-credentials supplied from a vault or environment variable.}
+DuckDB's secret directory and survives the session. That directory sits
+under the same "home" directory as extensions (\verb{~/.duckdb} when it
+exists, or \code{DUCKDB_R_HOME} / the \code{duckdb.home} option; see
+\code{?duckdb::duckdb_storage}), and with the temporary default the secret
+is lost with the session anyway. The default \code{FALSE} keeps it in memory
+only, which is the right choice for credentials supplied from a vault
+or environment variable.}
 }
 \value{
 Invisibly returns the secret's name (or \code{NA_character_} for an

--- a/man/ducklake_extension_available.Rd
+++ b/man/ducklake_extension_available.Rd
@@ -12,34 +12,41 @@ otherwise (including when a connection cannot be opened).
 }
 \description{
 Reports whether the \code{ducklake} DuckDB extension is already installed and
-can be loaded. The check opens a throwaway in-memory DuckDB connection with
-automatic extension installation turned off, so it never downloads anything
-and never writes to the extension cache in your home directory. It also
-leaves the package's own connection untouched.
+can be loaded. The check opens a throwaway in-memory DuckDB connection,
+asks DuckDB's extension catalog whether the extension is installed, and
+loads it only if so. Reading the catalog cannot download anything, and
+loading an installed extension does not reach the network, so the probe
+never downloads and never writes to the extension directory. The
+connection is opened on the directory duckdb would resolve for a new
+connection, so an existing \verb{~/.duckdb} is found, and the offer duckdb
+makes to create one is not triggered. The package's own connection is
+left untouched.
 }
 \details{
 Use it to guard code that should degrade gracefully when the extension is
 absent: examples, vignettes, tests, and conditional branches in scripts.
-The package's own examples are gated on it. To install the extension, call
-\code{\link[=install_ducklake]{install_ducklake()}}.
+The package's own examples are gated on it. There is no need to call it
+before \code{\link[=attach_ducklake]{attach_ducklake()}}, which installs the extension the first time it
+is needed; \code{\link[=install_ducklake]{install_ducklake()}} downloads it ahead of time.
 
-A \code{FALSE} on a machine where \code{\link[=install_ducklake]{install_ducklake()}} has already run usually
-means the extension went into a temporary directory: from duckdb 1.5.2
-on, extensions are kept under a "home" directory that defaults to a
-per-session temporary directory unless \code{DUCKDB_R_HOME} (or the
-\code{duckdb.home} option, or an existing \verb{~/.duckdb}) points somewhere
-durable. See \code{\link[=install_ducklake]{install_ducklake()}}.
+A \code{FALSE} on a machine where the extension was installed earlier usually
+means it went into a temporary directory. duckdb keeps extensions under a
+"home" directory: the \code{duckdb.home} option or \code{DUCKDB_R_HOME} when set,
+otherwise \verb{~/.duckdb} when it exists (in an interactive session duckdb
+offers to create it the first time it connects), otherwise a per-session
+temporary directory. See \code{?duckdb::duckdb_storage}.
 
 The result is cached for the rest of the session, since spinning up DuckDB
 to re-answer the same question is wasteful when dozens of examples ask it.
-\code{\link[=install_ducklake]{install_ducklake()}} clears the cache, so a \code{FALSE} answer becomes \code{TRUE}
-as soon as you install.
+\code{\link[=install_ducklake]{install_ducklake()}} and a first-use install by \code{\link[=attach_ducklake]{attach_ducklake()}} clear
+the cache, so a \code{FALSE} answer becomes \code{TRUE} as soon as the extension is
+there.
 }
 \examples{
 if (ducklake_extension_available()) {
   message("ducklake extension is ready to use")
 } else {
-  message("run install_ducklake() first")
+  message("attach_ducklake() will download it on first use")
 }
 }
 \seealso{

--- a/man/install_ducklake.Rd
+++ b/man/install_ducklake.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/install_ducklake.R
 \name{install_ducklake}
 \alias{install_ducklake}
-\title{Install the ducklake extension to duckdb}
+\title{Download the ducklake extension ahead of time}
 \usage{
 install_ducklake(backend = NULL)
 }
@@ -16,21 +16,24 @@ Invisibly, \code{NULL}. Called for its side effect of installing the
 DuckDB extensions into the local extension cache.
 }
 \description{
-Installs the ducklake DuckDB extension and optionally the extensions for
-alternative catalog backends (postgres, sqlite, mysql). Needs to run once
-per DuckDB version, provided DuckDB's extension directory survives the
-session (see Details).
+\code{\link[=attach_ducklake]{attach_ducklake()}} installs the ducklake DuckDB extension the first time
+it is needed, so most sessions never call this function. It downloads the
+extension now, and optionally the extensions for the other catalog
+backends (postgres, sqlite, mysql), for the cases where the download has
+to happen before a lake is attached: baking a container image, a CI setup
+step, or a machine that is offline at attach time.
 }
 \details{
-Where the extension lands depends on the duckdb R package. From duckdb
-1.5.2 on, extensions live under a "home" directory that defaults to a
-per-session temporary directory unless something durable is configured:
-the \code{DUCKDB_R_HOME} environment variable (set it in \verb{~/.Renviron} so every
-session sees it), the \code{duckdb.home} option, or an existing \verb{~/.duckdb}
-directory. With the temporary default, the extension is gone when R
-exits and the next session downloads it again. \code{install_ducklake()}
-reports the directory it installed into and says so when that directory
-is temporary.
+Where the extension lands is decided by the duckdb R package (see
+\code{?duckdb::duckdb_storage}). Extensions live under a "home" directory: the
+\code{duckdb.home} option or \code{DUCKDB_R_HOME} when set, otherwise \verb{~/.duckdb}
+when it exists (in an interactive session duckdb offers to create it the
+first time it connects), otherwise a per-session temporary directory.
+With the temporary directory the extension is gone when R exits and the
+next session downloads it again. \code{install_ducklake()} reports the
+directory it installed into and says so when that directory is temporary.
+For scripts and CI, set \code{DUCKDB_R_HOME} in \verb{~/.Renviron} or the job's
+environment to a directory that survives the session.
 }
 \note{
 On Windows the \code{postgres} and \code{mysql} extensions are not available

--- a/tests/testthat/test-extensions.R
+++ b/tests/testthat/test-extensions.R
@@ -1,0 +1,67 @@
+# Tests for the on-demand extension install path and its hints
+
+test_that("load_or_install_extension installs after a failed LOAD and says so", {
+  env <- get_ducklake_env()
+  old <- env$ext_available
+  on.exit(env$ext_available <- old, add = TRUE)
+  env$ext_available <- FALSE
+
+  executed <- character()
+  local_mocked_bindings(
+    db_execute = function(sql, ...) {
+      executed <<- c(executed, sql)
+      if (sql == "LOAD ducklake;" && !"INSTALL ducklake;" %in% executed) {
+        stop("Extension \"ducklake.duckdb_extension\" not found.")
+      }
+      invisible(NULL)
+    },
+    extension_directory = function(conn) file.path(tempdir(), "extensions")
+  )
+
+  expect_message(
+    load_or_install_extension("ducklake", conn = NULL),
+    "Installing the ducklake DuckDB extension"
+  )
+  expect_equal(
+    executed,
+    c("LOAD ducklake;", "INSTALL ducklake;", "LOAD ducklake;")
+  )
+  # a first-use install invalidates a cached FALSE from the probe
+  expect_null(env$ext_available)
+})
+
+test_that("load_or_install_extension only loads an installed extension", {
+  executed <- character()
+  local_mocked_bindings(
+    db_execute = function(sql, ...) {
+      executed <<- c(executed, sql)
+      invisible(NULL)
+    }
+  )
+
+  expect_silent(load_or_install_extension("httpfs", conn = NULL))
+  expect_equal(executed, "LOAD httpfs;")
+})
+
+test_that("extension_persistence_hint flags only a temporary directory", {
+  expect_length(extension_persistence_hint(NA_character_), 0)
+  expect_length(extension_persistence_hint(character()), 0)
+
+  durable <- file.path(dirname(tempdir()), "not-this-session", "extensions")
+  expect_length(extension_persistence_hint(durable), 0)
+
+  hint <- extension_persistence_hint(file.path(tempdir(), "extensions"))
+  expect_named(hint, c("!", "i"))
+  expect_match(hint[["!"]], "temporary")
+  expect_match(hint[["i"]], "DUCKDB_R_HOME")
+})
+
+test_that("storage_home_root is the parent of duckdb's extension directory", {
+  status <- data.frame(
+    kind = c("extensions", "stored_secrets"),
+    source = "shared",
+    directory = c("/home/me/.duckdb/extensions", "/home/me/.duckdb/stored_secrets")
+  )
+  expect_equal(storage_home_root(status), "/home/me/.duckdb")
+  expect_error(storage_home_root(status[2, ]), "extension directory")
+})

--- a/vignettes/clinical-trial-datalake.Rmd
+++ b/vignettes/clinical-trial-datalake.Rmd
@@ -73,10 +73,6 @@ This establishes the foundational infrastructure for our versioned data reposito
 We'll use a temporary directory for this vignette, but in practice you would specify a permanent location using the `lake_path` argument (e.g., a shared network drive or project directory).
 
 ```{r create-datalake}
-# Install the ducklake extension to duckdb (required once per system)
-# The ducklake extension only needs installing once per machine:
-# install_ducklake()
-
 # Define where to create a new data lake or access an existing one
 # For this vignette, we use vignette_temp_dir; in practice, use a permanent location
 # lake_path <- "/path/to/your/project/data_lake"

--- a/vignettes/data-inlining.Rmd
+++ b/vignettes/data-inlining.Rmd
@@ -51,8 +51,6 @@ files with a single call.
 ## Setup
 
 ```{r create-lake, message = FALSE}
-# The ducklake extension only needs installing once per machine:
-# install_ducklake()
 attach_ducklake("sensor_lake", lake_path = vignette_temp_dir)
 ```
 

--- a/vignettes/deployment.Rmd
+++ b/vignettes/deployment.Rmd
@@ -178,10 +178,10 @@ A few settings pay for themselves later. Set them when you create the lake,
 and they persist in the catalog for every client.
 
 ```{r day-one}
-# 1. Keep DuckDB's downloaded extensions between sessions (duckdb >= 1.5.2
-#    keeps them in a per-session temporary directory otherwise). Put this
-#    in ~/.Renviron, not in a script:
-#    DUCKDB_R_HOME=~/.duckdb
+# 1. Keep DuckDB's downloaded extensions between sessions. Interactively,
+#    say yes when duckdb offers to create ~/.duckdb. For scripts and CI,
+#    set DUCKDB_R_HOME=~/.duckdb in ~/.Renviron or the job's environment.
+#    A container image runs install_ducklake() at build time instead.
 
 # 2. Create the lake, and its schemas, in one snapshot
 attach_ducklake("trial", lake_path = "~/lakes/trial")

--- a/vignettes/ducklake.Rmd
+++ b/vignettes/ducklake.Rmd
@@ -46,16 +46,14 @@ on disk and where the catalog and the data files can live.
 
 ```{r install, eval = FALSE}
 install.packages("ducklake")
-
-# The DuckLake extension for DuckDB is downloaded once per machine
-install_ducklake()
 ```
 
-ducklake needs the duckdb package at version 1.5.2 or newer. From that
-version on, DuckDB keeps downloaded extensions in a temporary directory
-that disappears with the session, unless `DUCKDB_R_HOME` points somewhere
-permanent. Setting it in `~/.Renviron` (for example
-`DUCKDB_R_HOME=~/.duckdb`) makes the download a one-time event.
+ducklake needs the duckdb package at version 1.5.5 or newer. DuckLake
+itself is a DuckDB extension, and the first `attach_ducklake()` downloads
+it and says where it went. The first time duckdb connects in an interactive
+session it offers to create `~/.duckdb`; say yes, and the download happens
+once instead of once per session. For scripts and CI, set `DUCKDB_R_HOME`
+in `~/.Renviron` or the job's environment.
 
 ## Attach a lake
 

--- a/vignettes/modifying-tables.Rmd
+++ b/vignettes/modifying-tables.Rmd
@@ -31,8 +31,6 @@ library(ducklake)
 library(dplyr)
 
 # Setup for examples
-# The ducklake extension only needs installing once per machine:
-# install_ducklake()
 attach_ducklake("modifying_tables_lake", lake_path = vignette_temp_dir)
 
 # Load a sample dataset

--- a/vignettes/quack-remote-access.Rmd
+++ b/vignettes/quack-remote-access.Rmd
@@ -11,9 +11,9 @@ vignette: >
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  # Quack needs a running server and DuckDB 1.5.3 or newer, neither of which is
-  # available when this vignette is built. The examples are shown with their
-  # expected output rather than executed.
+  # Quack needs a running server, which is not available when this vignette
+  # is built. The examples are shown with their expected output rather than
+  # executed.
   eval = FALSE
 )
 ```
@@ -45,13 +45,7 @@ everyday R user, so the examples stay close to ordinary analysis work and do not
 assume any server administration experience.
 
 The code below is shown with its expected output but is not run when the vignette
-is built, because Quack needs a live server and a recent DuckDB. To follow along
-you need the `duckdb` R package at version 1.5.3 or newer:
-
-```{r version-check}
-packageVersion("duckdb")
-#> [1] '1.5.3'
-```
+is built, because Quack needs a live server.
 
 ## Installing the extension
 

--- a/vignettes/storage-and-backups.Rmd
+++ b/vignettes/storage-and-backups.Rmd
@@ -146,10 +146,6 @@ Let's create a sample DuckLake and explore what files it generates:
 lake_dir <- file.path(vignette_temp_dir, "storage_demo")
 dir.create(lake_dir, showWarnings = FALSE, recursive = TRUE)
 
-# Install ducklake extension
-# The ducklake extension only needs installing once per machine:
-# install_ducklake()
-
 # Create and populate a DuckLake
 attach_ducklake(
   ducklake_name = "demo_lake",

--- a/vignettes/time-travel.Rmd
+++ b/vignettes/time-travel.Rmd
@@ -45,10 +45,6 @@ This functionality is especially valuable in domains where data provenance and r
 We'll start by creating a new DuckLake and loading the mtcars dataset. We'll then make several modifications to demonstrate time travel functionality.
 
 ```{r create-datalake}
-# Install the ducklake extension (required once per system)
-# The ducklake extension only needs installing once per machine:
-# install_ducklake()
-
 # Create or attach to a data lake
 attach_ducklake(
   ducklake_name = "time_travel_demo",

--- a/vignettes/transactions.Rmd
+++ b/vignettes/transactions.Rmd
@@ -28,8 +28,6 @@ library(ducklake)
 library(dplyr)
 
 # Setup for examples
-# The ducklake extension only needs installing once per machine:
-# install_ducklake()
 attach_ducklake("transactions_lake", lake_path = vignette_temp_dir)
 ```
 

--- a/vignettes/visualizing-your-lake.Rmd
+++ b/vignettes/visualizing-your-lake.Rmd
@@ -51,9 +51,6 @@ We'll create a small lake and put a table through a few changes, recording
 authors and commit messages along the way.
 
 ```{r create-datalake}
-# The ducklake extension only needs installing once per machine:
-# install_ducklake()
-
 attach_ducklake(
   ducklake_name = "lake_viz_demo",
   lake_path = vignette_temp_dir


### PR DESCRIPTION
`attach_ducklake()` has always installed the ducklake extension the first time it is needed, after a message naming the directory, so the `install_ducklake()` step in the README and the articles was documentation only. This drops it from every quick-start path and documents `install_ducklake()` as the way to download ahead of time (container images, CI, machines that are offline at attach time). No load-time check is added: the package neither downloads nor starts DuckDB when it is loaded, and duckdb's own connect-time prompt handles the durable directory.

Also:

- The duckdb floor moves to 1.5.5, the release that settled where the R package keeps extensions and gave it an API. `ducklake_extension_available()` opens its probe on the directory `duckdb_storage_status()` reports, so it finds an existing `~/.duckdb` without triggering duckdb's offer to create one, and a first-use install clears the cached answer.
- The temporary-directory hint never showed on macOS for a first-use install, because the extension directory does not exist until `INSTALL` creates it and the path comparison only recognized existing paths. Fixed, with tests for the install path and the hint.
- CLAUDE.md records the no-load-hook decision and the 1.5.5 storage rules.

Verified locally: 845 tests pass with none skipped, spelling and pkgdown checks clean, first-use install exercised with a temporary and a durable home, and the probe confirmed prompt-free under a fake HOME.
