### PR TITLE
Classify plot_snapshots() changes per table and qualify swimlane lanes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # ducklake (development version)
 
+* `plot_snapshots()` classifies each snapshot by what it did to the table
+  being drawn. A transaction that updated one table in place and rebuilt
+  another used to color both as "created", because the whole snapshot was
+  classified by the highest-precedence change it carried; the single-table
+  timeline and the swimlane now read only the change-map entries that name
+  the table, so the updated table shows a data change and the rebuilt one a
+  creation. Swimlane lanes are schema-qualified whenever the lake keeps
+  tables outside `main`, so `bronze.dm` and `silver.dm` no longer share a
+  lane; a lake with everything in `main` keeps bare names.
+
 * The ducklake DuckDB extension no longer needs an install step. The code
   never required one: `attach_ducklake()` has always installed it on first
   use, after a message naming the directory. The README and the articles

--- a/R/plot_snapshots.R
+++ b/R/plot_snapshots.R
@@ -20,16 +20,20 @@
 #'
 #' @details
 #' Requires the ggplot2 package (listed in Suggests). Snapshot data comes from
-#' [list_table_snapshots()]; each snapshot is classified from its `changes`
-#' column into one of: created, schema change, data change, maintenance, or
-#' other. Authors and commit messages appear where they were recorded (see
-#' [set_snapshot_metadata()] and [commit_transaction()]).
+#' [list_table_snapshots()]; each snapshot is classified from the entries of
+#' its `changes` column that name the table into one of: created, schema
+#' change, data change, maintenance, or other. A transaction that updates
+#' one table in place and rebuilds another therefore shows a data change on
+#' the first and a creation on the second. Authors and commit messages
+#' appear where they were recorded (see [set_snapshot_metadata()] and
+#' [commit_transaction()]).
 #'
 #' Both layouts position snapshots by order rather than by clock time, so a
 #' history with months of silence between bursts of activity stays readable.
 #' In the swimlane, snapshots that touch no table (like the initial schema
 #' creation) appear in a `(lake)` lane, and the x axis labels show each
-#' snapshot's date.
+#' snapshot's date. Lanes carry schema-qualified names when the lake keeps
+#' tables outside `main`, so `bronze.dm` and `silver.dm` stay apart.
 #'
 #'
 #' @examplesIf ducklake_extension_available() && requireNamespace("ggplot2", quietly = TRUE)
@@ -60,6 +64,11 @@ plot_snapshots <- function(table_name = NULL, ducklake_name = NULL, conn = NULL)
     ))
   }
 
+  if (is.null(conn)) {
+    conn <- get_ducklake_connection()
+  }
+  ducklake_name <- infer_ducklake_name(ducklake_name, conn)
+
   snapshots <- list_table_snapshots(table_name, ducklake_name, conn)
   if (nrow(snapshots) == 0) {
     target <- if (is.null(table_name)) "this ducklake" else table_name
@@ -69,10 +78,13 @@ plot_snapshots <- function(table_name = NULL, ducklake_name = NULL, conn = NULL)
     ))
   }
 
-  snapshots$change_type <- classify_snapshot_changes(snapshots$changes)
   snapshots <- snapshots[order(snapshots$snapshot_time, snapshots$snapshot_id), ]
 
   if (!is.null(table_name)) {
+    # Classify each snapshot by what it did to this table, not by everything
+    # the transaction touched
+    targets <- table_change_targets(table_name, ducklake_name, conn)
+    snapshots$change_type <- classify_snapshot_changes(snapshots$changes, targets)
     plot_snapshot_commit_log(snapshots, table_name)
   } else {
     plot_snapshot_swimlane(snapshots, ducklake_name, conn)
@@ -191,17 +203,19 @@ plot_snapshot_commit_log <- function(snapshots, table_name) {
 #'
 #' @noRd
 plot_snapshot_swimlane <- function(snapshots, ducklake_name, conn) {
-  if (is.null(conn)) {
-    conn <- get_ducklake_connection()
-  }
-  ducklake_name <- infer_ducklake_name(ducklake_name, conn)
-
   snapshots$order <- seq_len(nrow(snapshots))
   id_names <- ducklake_table_id_names(ducklake_name, conn)
-  tables <- snapshot_change_tables(snapshots$changes, id_names)
+  attributed <- snapshot_table_changes(snapshots$changes, id_names)
 
-  d <- snapshots[rep(seq_len(nrow(snapshots)), lengths(tables)), ]
-  d$table <- unlist(tables)
+  d <- snapshots[
+    rep(seq_len(nrow(snapshots)), vapply(attributed, nrow, integer(1))),
+  ]
+  attributed <- do.call(rbind, attributed)
+  d$table <- display_table_names(attributed$table)
+  d$change_type <- factor(
+    attributed$change_type,
+    levels = names(snapshot_change_colors)
+  )
 
   # Lanes ordered by last activity so recently active tables sit on top and
   # stale ones sink to the bottom
@@ -243,26 +257,24 @@ format_gap_duration <- function(secs) {
   }
 }
 
-#' Current name for each table id in the lake's metadata catalog
+#' Current qualified name for each table id in the lake's metadata catalog
 #'
-#' Returns a named character vector mapping table_id to table_name. Renamed
-#' or replaced tables have several metadata rows per id; the one with the
-#' largest begin_snapshot holds the most recent name.
+#' Returns a named character vector mapping table_id to `schema.table`.
+#' Renamed or replaced tables have several metadata rows per id; the one
+#' with the largest begin_snapshot holds the most recent name.
 #'
 #' @noRd
 ducklake_table_id_names <- function(ducklake_name, conn) {
-  backend <- get_ducklake_backend(ducklake_name)
-  metadata_ref <- if (backend %in% c("postgres", "mysql")) {
-    paste0("__ducklake_metadata_", ducklake_name, ".ducklake_table")
-  } else {
-    paste0("__ducklake_metadata_", ducklake_name, ".main.ducklake_table")
-  }
+  prefix <- metadata_prefix(ducklake_name, conn)
   tables <- tryCatch(
     DBI::dbGetQuery(
       conn,
       sprintf(
-        "SELECT table_id, table_name FROM %s ORDER BY begin_snapshot",
-        quote_ident(metadata_ref, conn)
+        "SELECT t.table_id, s.schema_name || '.' || t.table_name AS table_name
+         FROM %s.ducklake_table t
+         JOIN %s.ducklake_schema s ON t.schema_id = s.schema_id
+         ORDER BY t.begin_snapshot, s.begin_snapshot",
+        prefix, prefix
       )
     ),
     error = function(e) data.frame(table_id = numeric(0), table_name = character(0))
@@ -273,44 +285,88 @@ ducklake_table_id_names <- function(ducklake_name, conn) {
   ]
 }
 
-#' Attribute each snapshot's changes to table names
+#' Attribute each snapshot's changes to tables, each with its own change type
 #'
 #' Values under table-related change keys are either qualified names
-#' ("main.fleet", from creates) or numeric table ids ("1", from DML), so ids
-#' go through the metadata map and names get their schema prefix stripped.
-#' Snapshots with no table attribution (like schema creation) fall into a
-#' "(lake)" lane.
+#' ("main.fleet", from creates and renames) or numeric table ids ("1", from
+#' row changes, alters, drops, and flushes), so ids go through the metadata
+#' map to their qualified name. A table's change type comes from the entries
+#' that name it, so one transaction can leave a data change on one table and
+#' a creation on another. Snapshots with no table attribution (like schema
+#' creation) fall into a "(lake)" lane classified from the whole entry.
 #'
 #' @param changes The list-column from snapshots(): one data.frame of
 #'   key/value pairs per snapshot.
 #' @param id_names Named character vector from ducklake_table_id_names().
-#' @returns A list of character vectors, one per snapshot.
+#' @returns A list of data frames, one per snapshot, with columns `table`
+#'   and `change_type`.
 #' @noRd
-snapshot_change_tables <- function(changes, id_names) {
+snapshot_table_changes <- function(changes, id_names) {
+  lake_lane <- function(entry) {
+    data.frame(
+      table = "(lake)",
+      change_type = classify_change_tokens(change_keys(entry)),
+      stringsAsFactors = FALSE
+    )
+  }
   attribute_one <- function(entry) {
     if (!is.data.frame(entry) || nrow(entry) == 0) {
-      return("(lake)")
+      return(lake_lane(entry))
     }
-    keep <- !startsWith(entry$key, "schemas")
-    values <- unique(unlist(entry$value[keep]))
-    values <- values[!is.na(values)]
+    keep <- !startsWith(as.character(entry$key), "schemas")
+    values <- unique(unlist(entry$value[keep], use.names = FALSE))
+    values <- as.character(values[!is.na(values)])
     if (length(values) == 0) {
-      return("(lake)")
+      return(lake_lane(entry))
     }
-    is_id <- grepl("^[0-9]+$", values)
-    mapped <- character(length(values))
-    mapped[is_id] <- ifelse(
-      values[is_id] %in% names(id_names),
-      id_names[values[is_id]],
-      paste("table", values[is_id])
-    )
-    mapped[!is_id] <- sub("^.*\\.", "", values[!is_id])
-    unique(mapped)
+    lanes <- resolve_change_values(values, id_names)
+    rows <- lapply(unique(lanes), function(lane) {
+      data.frame(
+        table = lane,
+        change_type = classify_change_tokens(
+          change_keys(entry, names(lanes)[lanes == lane])
+        ),
+        stringsAsFactors = FALSE
+      )
+    })
+    do.call(rbind, rows)
   }
   lapply(changes, attribute_one)
 }
 
-#' Classify a snapshot's changes into a change category
+#' Map change-map values to table names
+#'
+#' Ids go through the metadata map; names stay as they are. An id the
+#' catalog does not know keeps a placeholder lane rather than being dropped.
+#' The result is named by the original values, so the caller can find the
+#' values behind each lane.
+#' @noRd
+resolve_change_values <- function(values, id_names) {
+  is_id <- grepl("^[0-9]+$", values)
+  resolved <- values
+  resolved[is_id] <- ifelse(
+    values[is_id] %in% names(id_names),
+    id_names[values[is_id]],
+    paste("table", values[is_id])
+  )
+  stats::setNames(resolved, values)
+}
+
+#' Lane labels for the swimlane
+#'
+#' Bare names when every table lives in `main`, schema-qualified names
+#' otherwise, so same-named tables in different schemas keep separate lanes.
+#' @noRd
+display_table_names <- function(x) {
+  qualified <- grepl(".", x, fixed = TRUE)
+  schemas <- unique(sub("\\.[^.]*$", "", x[qualified]))
+  if (length(schemas) <= 1 && all(schemas == "main")) {
+    x[qualified] <- sub("^main\\.", "", x[qualified])
+  }
+  x
+}
+
+#' Classify snapshots' changes into change categories
 #'
 #' The changes column from snapshots() arrives as a list column where each
 #' element is a data.frame of key/value pairs (keys are change tokens like
@@ -319,36 +375,69 @@ snapshot_change_tables <- function(changes, id_names) {
 #' Categories are checked in priority order; unrecognized tokens fall through
 #' to "other".
 #'
+#' @param targets Optional character vector of the change-map values that
+#'   identify one table (its qualified name and every id it has had, from
+#'   table_change_targets()). When given, only the entries that name that
+#'   table count, so a snapshot is classified by what it did to the table
+#'   rather than by everything the transaction touched.
 #' @noRd
-classify_snapshot_changes <- function(changes) {
+classify_snapshot_changes <- function(changes, targets = NULL) {
   if (!is.list(changes)) {
     changes <- as.list(changes)
   }
-  classify_one <- function(tokens) {
-    tokens <- if (is.data.frame(tokens)) tokens$key else unlist(tokens)
-    if (length(tokens) == 0 || all(is.na(tokens))) {
-      return("other")
-    }
-    x <- paste(tokens, collapse = ", ")
-    if (grepl("\\btables_created\\b|\\bschemas_created\\b", x)) {
-      return("created")
-    }
-    if (grepl("\\btables_altered\\b|\\btables_dropped\\b", x)) {
-      return("schema change")
-    }
-    if (grepl(
-      "\\btables_inserted_into\\b|\\btables_deleted_from\\b|\\binlined_insert\\b|\\binlined_delete\\b",
-      x
-    )) {
-      return("data change")
-    }
-    if (grepl("\\bflushed_inlined\\b|\\bcompacted\\b", x)) {
-      return("maintenance")
-    }
-    "other"
-  }
   factor(
-    vapply(changes, classify_one, character(1), USE.NAMES = FALSE),
-    levels = c("created", "schema change", "data change", "maintenance", "other")
+    vapply(
+      changes,
+      function(entry) classify_change_tokens(change_keys(entry, targets)),
+      character(1),
+      USE.NAMES = FALSE
+    ),
+    levels = names(snapshot_change_colors)
   )
+}
+
+#' The change tokens of one snapshot entry
+#'
+#' For a key/value data.frame, the keys, optionally only those whose values
+#' include one of `targets`; character input is returned as is.
+#' @noRd
+change_keys <- function(entry, targets = NULL) {
+  if (!is.data.frame(entry)) {
+    return(unlist(entry))
+  }
+  keys <- as.character(entry$key)
+  if (is.null(targets)) {
+    return(keys)
+  }
+  named <- vapply(
+    entry$value,
+    function(v) any(as.character(v) %in% targets),
+    logical(1)
+  )
+  keys[named]
+}
+
+#' One change category for a set of change tokens, in priority order
+#' @noRd
+classify_change_tokens <- function(tokens) {
+  if (length(tokens) == 0 || all(is.na(tokens))) {
+    return("other")
+  }
+  x <- paste(tokens, collapse = ", ")
+  if (grepl("\\btables_created\\b|\\bschemas_created\\b", x)) {
+    return("created")
+  }
+  if (grepl("\\btables_altered\\b|\\btables_dropped\\b", x)) {
+    return("schema change")
+  }
+  if (grepl(
+    "\\btables_inserted_into\\b|\\btables_deleted_from\\b|\\binlined_insert\\b|\\binlined_delete\\b",
+    x
+  )) {
+    return("data change")
+  }
+  if (grepl("\\bflushed_inlined\\b|\\bcompacted\\b", x)) {
+    return("maintenance")
+  }
+  "other"
 }

--- a/R/table_metadata.R
+++ b/R/table_metadata.R
@@ -315,12 +315,27 @@ table_ids_for_name <- function(table, schema, ducklake_name,
   )
 }
 
+#' The change-map values that identify a table
+#'
+#' Creates and renames name the table (`schema.table`); row changes,
+#' alters, drops, and flushes carry its numeric id, and a renamed or
+#' replaced table has had several ids, so every id the name has had in the
+#' schema counts.
+#'
+#' @returns A character vector: the qualified name and the ids as strings.
+#' @noRd
+table_change_targets <- function(table_name, ducklake_name,
+                                 conn = get_ducklake_connection()) {
+  parts <- split_table_name(table_name)
+  schema <- if (is.null(parts$schema)) "main" else parts$schema
+  ids <- table_ids_for_name(parts$table, schema, ducklake_name, conn)
+  c(paste0(schema, ".", parts$table), as.character(ids))
+}
+
 #' Which snapshots touched a table?
 #'
-#' The `changes` column of `snapshots()` maps change keys to values. Creates
-#' and drops name the table (`main.cars`); row-level changes carry its
-#' numeric id only, and a renamed or replaced table has had several ids, so
-#' every id the name has had in the schema counts. Handles both the
+#' Matches the `changes` column of `snapshots()` against the values that
+#' identify the table (see table_change_targets()). Handles both the
 #' key/value data frames the duckdb driver returns and a plain
 #' comma-separated string.
 #'
@@ -329,11 +344,7 @@ table_ids_for_name <- function(table, schema, ducklake_name,
 #' @noRd
 snapshots_touching_table <- function(changes, table_name, ducklake_name,
                                      conn = get_ducklake_connection()) {
-  parts <- split_table_name(table_name)
-  schema <- if (is.null(parts$schema)) "main" else parts$schema
-  ids <- table_ids_for_name(parts$table, schema, ducklake_name, conn)
-  targets <- c(paste0(schema, ".", parts$table), as.character(ids))
-
+  targets <- table_change_targets(table_name, ducklake_name, conn)
   vapply(
     changes,
     function(entry) any(change_values(entry) %in% targets),

--- a/man/plot_snapshots.Rd
+++ b/man/plot_snapshots.Rd
@@ -29,16 +29,20 @@ active and stale tables read at a glance.
 }
 \details{
 Requires the ggplot2 package (listed in Suggests). Snapshot data comes from
-\code{\link[=list_table_snapshots]{list_table_snapshots()}}; each snapshot is classified from its \code{changes}
-column into one of: created, schema change, data change, maintenance, or
-other. Authors and commit messages appear where they were recorded (see
-\code{\link[=set_snapshot_metadata]{set_snapshot_metadata()}} and \code{\link[=commit_transaction]{commit_transaction()}}).
+\code{\link[=list_table_snapshots]{list_table_snapshots()}}; each snapshot is classified from the entries of
+its \code{changes} column that name the table into one of: created, schema
+change, data change, maintenance, or other. A transaction that updates
+one table in place and rebuilds another therefore shows a data change on
+the first and a creation on the second. Authors and commit messages
+appear where they were recorded (see \code{\link[=set_snapshot_metadata]{set_snapshot_metadata()}} and
+\code{\link[=commit_transaction]{commit_transaction()}}).
 
 Both layouts position snapshots by order rather than by clock time, so a
 history with months of silence between bursts of activity stays readable.
 In the swimlane, snapshots that touch no table (like the initial schema
 creation) appear in a \code{(lake)} lane, and the x axis labels show each
-snapshot's date.
+snapshot's date. Lanes carry schema-qualified names when the lake keeps
+tables outside \code{main}, so \code{bronze.dm} and \code{silver.dm} stay apart.
 }
 \examples{
 \dontshow{if (ducklake_extension_available() && requireNamespace("ggplot2", quietly = TRUE)) withAutoprint(\{ # examplesIf}

--- a/tests/testthat/test-plot-snapshots.R
+++ b/tests/testthat/test-plot-snapshots.R
@@ -107,7 +107,7 @@ test_that("classify_snapshot_changes maps tokens in priority order", {
   )
 })
 
-test_that("snapshot_change_tables attributes names, ids, and lake-level changes", {
+test_that("snapshot_table_changes gives each table its own change type", {
   changes <- list(
     data.frame(key = "schemas_created", value = I(list("main"))),
     data.frame(
@@ -115,17 +115,61 @@ test_that("snapshot_change_tables attributes names, ids, and lake-level changes"
       value = I(list("main.fleet", "1"))
     ),
     data.frame(key = "inlined_insert", value = I(list("1"))),
-    data.frame(key = "tables_inserted_into", value = I(list("99")))
+    data.frame(key = "tables_inserted_into", value = I(list("99"))),
+    # One transaction: rows updated in fleet, crew rebuilt (drop + create)
+    data.frame(
+      key = c("tables_created", "tables_dropped", "inlined_insert", "inlined_delete"),
+      value = I(list("main.crew", "2", c("1", "3"), "1"))
+    )
   )
-  id_names <- c("1" = "fleet", "2" = "crew")
+  id_names <- c("1" = "main.fleet", "2" = "main.crew", "3" = "main.crew")
 
-  result <- snapshot_change_tables(changes, id_names)
+  result <- snapshot_table_changes(changes, id_names)
 
-  expect_equal(result[[1]], "(lake)")
-  expect_equal(result[[2]], "fleet")
-  expect_equal(result[[3]], "fleet")
+  expect_equal(result[[1]]$table, "(lake)")
+  expect_equal(result[[1]]$change_type, "created")
+  expect_equal(result[[2]]$table, "main.fleet")
+  expect_equal(result[[2]]$change_type, "created")
+  expect_equal(result[[3]]$change_type, "data change")
   # Unknown ids keep a placeholder lane rather than being dropped
-  expect_equal(result[[4]], "table 99")
+  expect_equal(result[[4]]$table, "table 99")
+  multi <- result[[5]]
+  expect_setequal(multi$table, c("main.crew", "main.fleet"))
+  expect_equal(multi$change_type[multi$table == "main.fleet"], "data change")
+  expect_equal(multi$change_type[multi$table == "main.crew"], "created")
+})
+
+test_that("classify_snapshot_changes can classify by what a snapshot did to one table", {
+  changes <- list(data.frame(
+    key = c("tables_created", "tables_dropped", "inlined_insert", "inlined_delete"),
+    value = I(list("silver.dm", "4", c("5", "6"), "5"))
+  ))
+
+  expect_equal(as.character(classify_snapshot_changes(changes)), "created")
+  expect_equal(
+    as.character(classify_snapshot_changes(changes, targets = c("silver.dm", "4", "6"))),
+    "created"
+  )
+  expect_equal(
+    as.character(classify_snapshot_changes(changes, targets = c("main.t", "5"))),
+    "data change"
+  )
+  expect_equal(
+    as.character(classify_snapshot_changes(changes, targets = "99")),
+    "other"
+  )
+})
+
+test_that("display_table_names qualifies lanes only when tables leave main", {
+  expect_equal(
+    display_table_names(c("main.fleet", "main.crew", "(lake)", "table 99")),
+    c("fleet", "crew", "(lake)", "table 99")
+  )
+  expect_equal(
+    display_table_names(c("bronze.dm", "silver.dm", "main.notes", "(lake)")),
+    c("bronze.dm", "silver.dm", "main.notes", "(lake)")
+  )
+  expect_equal(display_table_names("(lake)"), "(lake)")
 })
 
 test_that("format_gap_duration picks sensible units", {
@@ -171,4 +215,70 @@ test_that("commit log handles a single snapshot without metadata columns", {
 
   expect_s3_class(p, "ggplot")
   expect_true(all(is.na(p$data$annotation)))
+})
+
+test_that("a multi-table transaction is classified per table", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("ggplot2")
+
+  lake <- create_temp_ducklake()
+
+  create_table(data.frame(id = 1:3, v = c("a", "b", "c")), "snap_updated")
+  create_table(data.frame(id = 1:3), "snap_replaced")
+  with_transaction({
+    rows_update(
+      get_ducklake_table("snap_updated"),
+      data.frame(id = 1, v = "z"),
+      by = "id"
+    )
+    replace_table(data.frame(id = 1:5), "snap_replaced", .quiet = TRUE)
+  })
+  latest <- max(list_table_snapshots()$snapshot_id)
+
+  updated <- plot_snapshots("snap_updated")$data
+  expect_equal(
+    as.character(updated$change_type[updated$snapshot_id == latest]),
+    "data change"
+  )
+  replaced <- plot_snapshots("snap_replaced")$data
+  expect_equal(
+    as.character(replaced$change_type[replaced$snapshot_id == latest]),
+    "created"
+  )
+
+  lanes <- plot_snapshots(ducklake_name = lake$ducklake_name)$data
+  lanes <- lanes[lanes$snapshot_id == latest, ]
+  expect_equal(
+    as.character(lanes$change_type[lanes$table == "snap_updated"]),
+    "data change"
+  )
+  expect_equal(
+    as.character(lanes$change_type[lanes$table == "snap_replaced"]),
+    "created"
+  )
+
+  cleanup_temp_ducklake(lake)
+})
+
+test_that("swimlane lanes carry schema names when tables live in several schemas", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+  skip_if_not_installed("ggplot2")
+
+  lake <- create_temp_ducklake()
+
+  create_schema("bronze")
+  create_schema("silver")
+  create_table(mtcars[1:3, ], "bronze.dm")
+  create_table(mtcars[1:3, ], "silver.dm")
+
+  d <- plot_snapshots(ducklake_name = lake$ducklake_name)$data
+  expect_true(all(c("bronze.dm", "silver.dm") %in% levels(d$table)))
+  expect_false("dm" %in% levels(d$table))
+  # Each table was created once, so each lane holds one point
+  expect_equal(sum(d$table == "bronze.dm"), 1L)
+  expect_equal(sum(d$table == "silver.dm"), 1L)
+
+  cleanup_temp_ducklake(lake)
 })


### PR DESCRIPTION
`plot_snapshots()` classified a snapshot from its whole change map, so a transaction that updated one table in place and rebuilt another colored both as "created". The lake-wide swimlane also resolved table ids to bare names, which put `bronze.dm` and `silver.dm` in one "dm" lane. Both showed up while rendering the clinical article.

- A new helper builds the change-map values that identify a table (its `schema.table` name and every id it has had). The single-table timeline classifies each snapshot from the entries carrying those values, and `snapshots_touching_table()` reuses the helper.
- The swimlane attributes each snapshot to tables and classifies per table, so one commit can show a data change on one lane and a creation on another.
- Ids resolve to schema-qualified names through the metadata catalog. Lanes stay bare when every table lives in `main` and are qualified otherwise.
- Key names and value shapes were confirmed against DuckLake 1.0: creates and renames carry names; row changes, alters, drops, and flushes carry ids; the inlined keys are `inlined_insert` and `inlined_delete`.

Tests cover a multi-table transaction, same-named tables in two schemas, and the classifier, attribution, and lane-display helpers. `R CMD check` is clean.
