### PR TITLE
Label the creation snapshot and add a session default author

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,3 +132,31 @@
   admiral layers' traceability is ADaM metadata. The article claims no
   "Part 11 compliance"; it maps the snapshot history onto the audit-trail
   elements in FDA's 2024 Q&A (Q12-Q14) and cites ICH E6(R3) section 4.2.2.
+- **Snapshot 0 is labeled at attach time, by one conditional UPDATE**
+  (2026-09-11). DuckLake writes snapshot 0 itself during ATTACH and
+  ignores `set_commit_message()` around it (confirmed on DuckDB 1.5.5:
+  `BEGIN; ATTACH ...; CALL lake.set_commit_message(...); COMMIT` leaves it
+  NULL), and no ATTACH option or setting supplies a default author. So
+  `attach_ducklake()` runs one UPDATE on `ducklake_snapshot_changes`
+  (`snapshot_id = 0`, all three fields NULL, exactly one row in
+  `ducklake_snapshot`) after creating a lake; the rows-affected count says
+  whether the lake was new, with no probe-then-write window. It skips
+  read-only and pinned attaches (a pinned attach leaves the metadata
+  catalog writable), `create = FALSE`, a local catalog file that existed
+  before the ATTACH, and an open transaction (a DuckDB transaction writes
+  to one attached database, so a label there blocks the lake writes after
+  it). Silent; warns on failure. A read-only ATTACH cannot create a lake,
+  so that guard matters only for existing lakes on server catalogs.
+- **`ducklake.author` applies at the package's commit points**
+  (2026-09-11): `commit_transaction()` (so `with_transaction()` and
+  `restore_table_version()`) and the creation snapshot. Not
+  `set_snapshot_metadata()`, where the person labeling is not always the
+  one who committed, and not autocommit writes, which record no metadata.
+  An empty string is refused, so an unset environment variable fails
+  loudly instead of recording `""`.
+- **`metadata_schema` lives in the lake registry** (2026-09-11). The
+  metadata database is hidden from `duckdb_databases()` and
+  `duckdb_tables()`, so the schema cannot be discovered after ATTACH;
+  `register_lake()` keeps it, and `metadata_prefix()` and
+  `get_metadata_table()` read it there. SQLite catalogs refuse
+  `METADATA_SCHEMA`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,33 @@
 # ducklake (development version)
 
+* `attach_ducklake()` labels the creation snapshot of a lake it creates.
+  DuckLake writes snapshot 0 itself when it makes a lake, with no author
+  and no commit message, so every history began with an `<NA>` row. The
+  new `commit_message` (default `"Create lake"`) and `author` arguments
+  are written onto snapshot 0 right after the lake is created, with the
+  same metadata update `set_snapshot_metadata()` uses, because DuckLake
+  does not take `set_commit_message()` for that snapshot. A lake that
+  already exists is left alone, and so is a read-only, snapshot-pinned, or
+  in-transaction attach; `commit_message = NULL` keeps the old behavior.
+  `set_snapshot_metadata()` gains `snapshot_id`, so the creation snapshot
+  of an existing lake, or any other snapshot, can be labeled after the
+  fact; it still fills blanks only unless `overwrite = TRUE`, and its
+  confirmation now names the snapshot.
+
+* New `ducklake.author` option: the author recorded on every snapshot the
+  session commits without naming one, through `commit_transaction()`,
+  `with_transaction()`, `restore_table_version()`, and the creation
+  snapshot `attach_ducklake()` labels. An `author` argument still wins.
+  `set_snapshot_metadata()` does not read it, and a write made outside a
+  transaction records no author, as before.
+
+* The metadata readers honor the `metadata_schema` a lake was attached
+  with. They looked in the catalog's default schema whatever the attach
+  said, so `set_snapshot_metadata()`, `get_table_comments()`,
+  `get_table_partitions()`, `get_table_sorting()`, `get_table_info()`, and
+  `get_metadata_table()` failed on such a lake; the schema is now kept
+  with the lake's registry entry and used by all of them.
+
 * `plot_snapshots()` classifies each snapshot by what it did to the table
   being drawn. A transaction that updated one table in place and rebuilt
   another used to color both as "created", because the whole snapshot was

--- a/R/attach_ducklake.R
+++ b/R/attach_ducklake.R
@@ -2,7 +2,8 @@
 #'
 #' Wrapper for the ducklake [ATTACH](https://ducklake.select/docs/stable/duckdb/usage/connecting) command.
 #' Creates a new DuckLake if the specified name does not exist, or connects to
-#' an existing one. The lake can be detached with [detach_ducklake()].
+#' an existing one, and labels the creation snapshot of a lake it creates.
+#' The lake can be detached with [detach_ducklake()].
 #'
 #' By default DuckDB is used as the catalog database. Alternative backends
 #' (PostgreSQL, SQLite, MySQL) can be selected with the `backend` parameter,
@@ -85,8 +86,29 @@
 #'   holds this lake's metadata tables (DuckLake's `METADATA_SCHEMA`,
 #'   default `main`). Lets several lakes share one PostgreSQL database,
 #'   each in its own schema.
+#' @param author Author to record on snapshot 0, the creation snapshot, when
+#'   this call creates the lake. Defaults to the `ducklake.author` option
+#'   when it is set (see `?ducklake`), otherwise none. Not written for a
+#'   lake that already exists.
+#' @param commit_message Commit message to record on snapshot 0 when this
+#'   call creates the lake (default `"Create lake"`). `NULL`, with no
+#'   author, leaves snapshot 0 as DuckLake writes it, without metadata.
 #'
 #' @details
+#' DuckLake writes snapshot 0 itself when it creates a lake, with no author
+#' and no commit message. When this call creates the lake, it fills those
+#' two fields on snapshot 0 from `author` and `commit_message`, the way
+#' [set_snapshot_metadata()] labels a snapshot after the fact, so the
+#' history from [list_table_snapshots()] starts with a labeled entry.
+#' Nothing is written when the lake already exists, when `read_only` is
+#' set, when the attach is pinned with `snapshot_version` or
+#' `snapshot_time`, or when the call runs inside an open transaction;
+#' `set_snapshot_metadata(snapshot_id = 0)` labels such a lake later. The
+#' write is silent, and a failure to write is a warning, not an error. For
+#' a PostgreSQL or MySQL catalog, whether the lake already existed is read
+#' from the catalog after the attach (one snapshot, id 0, no metadata), so
+#' a lake another client created and never wrote to is labeled too.
+#'
 #' For credential management with PostgreSQL or MySQL, consider DuckDB's
 #' built-in secrets manager instead of embedding credentials in the connection
 #' string:
@@ -114,7 +136,8 @@
 #' `type = "azure"` does not work there; explicit S3 keys do.
 #'
 #' @returns Invisibly, `NULL`. Called for its side effect of attaching the
-#'   DuckLake catalog to the package's DuckDB connection.
+#'   DuckLake catalog to the package's DuckDB connection and, for a lake it
+#'   creates, of labeling snapshot 0.
 #' @family connection management
 #' @export
 #'
@@ -124,7 +147,7 @@
 #' # DuckDB catalog (default)
 #' lake_dir <- tempfile("my_lake_")
 #' dir.create(lake_dir)
-#' attach_ducklake("my_lake", lake_path = lake_dir)
+#' attach_ducklake("my_lake", lake_path = lake_dir, author = "Data Engineer")
 #' detach_ducklake("my_lake")
 #'
 #' # Custom inlining threshold for a streaming workload
@@ -225,9 +248,13 @@ attach_ducklake <- function(ducklake_name, lake_path,
                              snapshot_time = NULL,
                              automatic_migration = FALSE,
                              create = TRUE,
-                             metadata_schema = NULL) {
+                             metadata_schema = NULL,
+                             author = NULL,
+                             commit_message = "Create lake") {
   backend <- match.arg(backend)
   check_identifier(ducklake_name)
+  author <- resolve_author(author)
+  check_optional_string(commit_message, "commit_message")
 
   if (!is.null(snapshot_version) && !is.null(snapshot_time)) {
     cli::cli_abort(
@@ -281,24 +308,32 @@ attach_ducklake <- function(ducklake_name, lake_path,
     }
   }
   
-  # DuckDB cannot create or write a database file on object storage, so a
-  # writable duckdb-backend lake needs its catalog on local disk
-  if (backend == "duckdb" && !read_only) {
-    catalog_path <- if (!is.null(catalog_connection_string)) {
+  # The catalog file of a file-based backend, NULL for a server catalog.
+  # Whether it exists is noted before ATTACH, which creates it, so a lake
+  # that was already there can be told from one this call makes.
+  catalog_path <- switch(backend,
+    duckdb = if (!is.null(catalog_connection_string)) {
       catalog_connection_string
     } else {
       file.path(lake_path, paste0(ducklake_name, ".ducklake"))
-    }
-    if (is_remote_path(catalog_path)) {
-      cli::cli_abort(c(
-        "DuckDB cannot write its catalog file to object storage.",
-        "x" = "The catalog would live at {.val {catalog_path}}.",
-        "i" = "Pass {.arg catalog_connection_string} with a local path for the catalog file; {.arg lake_path} then only sets where the Parquet data goes.",
-        "i" = "Or attach an existing remote catalog with {.code read_only = TRUE}.",
-        "i" = "Or pick a {.arg backend} whose catalog lives elsewhere, such as {.val sqlite} or {.val postgres}."
-      ))
-    }
+    },
+    sqlite = catalog_connection_string,
+    NULL
+  )
+
+  # DuckDB cannot create or write a database file on object storage, so a
+  # writable duckdb-backend lake needs its catalog on local disk
+  if (backend == "duckdb" && !read_only && is_remote_path(catalog_path)) {
+    cli::cli_abort(c(
+      "DuckDB cannot write its catalog file to object storage.",
+      "x" = "The catalog would live at {.val {catalog_path}}.",
+      "i" = "Pass {.arg catalog_connection_string} with a local path for the catalog file; {.arg lake_path} then only sets where the Parquet data goes.",
+      "i" = "Or attach an existing remote catalog with {.code read_only = TRUE}.",
+      "i" = "Or pick a {.arg backend} whose catalog lives elsewhere, such as {.val sqlite} or {.val postgres}."
+    ))
   }
+  catalog_existed <- !is.null(catalog_path) &&
+    !is_remote_path(catalog_path) && file.exists(catalog_path)
 
   if (backend == "mysql") {
     cli::cli_warn(c(
@@ -316,9 +351,13 @@ attach_ducklake <- function(ducklake_name, lake_path,
   }, error = function(e) character(0))
 
   if (ducklake_name %in% attached) {
-    # Already attached - just switch to it
+    # Already attached - just switch to it. The registry keeps the metadata
+    # schema of the first attach unless this call names one.
     db_execute(sprintf("USE %s;", quote_ident(ducklake_name, conn)))
-    register_lake(ducklake_name, backend, catalog_connection_string)
+    if (is.null(metadata_schema)) {
+      metadata_schema <- .ducklake_env$lakes[[ducklake_name]]$metadata_schema
+    }
+    register_lake(ducklake_name, backend, catalog_connection_string, metadata_schema)
     return(invisible(NULL))
   }
 
@@ -345,7 +384,19 @@ attach_ducklake <- function(ducklake_name, lake_path,
                                   metadata_schema)
   db_execute(attach_sql)
   db_execute(sprintf("USE %s;", quote_ident(ducklake_name, conn)))
-  register_lake(ducklake_name, backend, catalog_connection_string)
+  register_lake(ducklake_name, backend, catalog_connection_string, metadata_schema)
+
+  # Label snapshot 0 when this call created the lake. Not on a read-only or
+  # pinned attach (pinning leaves the metadata catalog writable, so this
+  # test is what stops the write), not on a lake that was already there,
+  # and not inside an open transaction: a transaction can write to one
+  # attached database, so a label there would block the lake writes that
+  # follow it.
+  if (isTRUE(create) && !read_only &&
+      is.null(snapshot_version) && is.null(snapshot_time) &&
+      !catalog_existed && !in_transaction(conn)) {
+    label_creation_snapshot(ducklake_name, author, commit_message, conn)
+  }
 
   invisible(NULL)
 }

--- a/R/connection.R
+++ b/R/connection.R
@@ -205,20 +205,23 @@ close_ducklake_connection <- function(warn_not_owned = TRUE) {
   invisible(TRUE)
 }
 
-#' Record an attached lake's backend and connection string
+#' Record an attached lake's backend, connection string, and metadata schema
 #'
 #' Attached lakes are tracked per name so that sessions with several lakes
 #' attached at once (possibly on different backends) resolve backend-specific
-#' behaviour correctly.
+#' behaviour correctly. The metadata schema is kept because the metadata
+#' database cannot be inspected for it after the attach.
 #'
 #' @noRd
-register_lake <- function(ducklake_name, backend, catalog_connection_string = NULL) {
+register_lake <- function(ducklake_name, backend, catalog_connection_string = NULL,
+                          metadata_schema = NULL) {
   if (is.null(.ducklake_env$lakes)) {
     .ducklake_env$lakes <- list()
   }
   .ducklake_env$lakes[[ducklake_name]] <- list(
     backend = backend,
-    catalog_connection_string = catalog_connection_string
+    catalog_connection_string = catalog_connection_string,
+    metadata_schema = metadata_schema
   )
   invisible(NULL)
 }

--- a/R/ducklake-package.R
+++ b/R/ducklake-package.R
@@ -1,5 +1,13 @@
 #' @section Package options:
 #' \describe{
+#'   \item{`ducklake.author`}{The author recorded on the snapshots this
+#'     session commits when a call does not name one: `commit_transaction()`,
+#'     `with_transaction()`, `restore_table_version()`, and the creation
+#'     snapshot `attach_ducklake()` labels. An `author` argument wins over
+#'     the option. `set_snapshot_metadata()` does not read it, because
+#'     labeling a snapshot after the fact is a deliberate edit, and a write
+#'     made outside a transaction (`create_table()` on its own) records no
+#'     author either way. Unset by default.}
 #'   \item{`ducklake.verbose`}{When `FALSE`, the confirmations the package
 #'     emits after each operation ("Committed snapshot 3: ...", "Added column
 #'     ...") are suppressed, which keeps pipeline logs quiet. Warnings,

--- a/R/get_ducklake_table.R
+++ b/R/get_ducklake_table.R
@@ -116,13 +116,18 @@ get_metadata_table <- function(tbl_name, ducklake_name = NULL) {
     })
   }
   
-  # Metadata tables are in the __ducklake_metadata_[ducklake_name] database.
-  # DuckDB and SQLite use a .main. schema qualifier; PostgreSQL and MySQL do not.
+  # Metadata tables live in the __ducklake_metadata_[ducklake_name]
+  # database: in the schema the lake was attached with, else main for
+  # DuckDB and SQLite catalogs and the top level for PostgreSQL and MySQL
+  metadata_db <- paste0("__ducklake_metadata_", ducklake_name)
+  schema <- .ducklake_env$lakes[[ducklake_name]]$metadata_schema
   backend <- get_ducklake_backend(ducklake_name)
-  if (backend %in% c("postgres", "mysql")) {
-    metadata_tbl_name <- paste0("__ducklake_metadata_", ducklake_name, ".", tbl_name)
+  metadata_tbl_name <- if (!is.null(schema)) {
+    paste(metadata_db, schema, tbl_name, sep = ".")
+  } else if (backend %in% c("postgres", "mysql")) {
+    paste(metadata_db, tbl_name, sep = ".")
   } else {
-    metadata_tbl_name <- paste0("__ducklake_metadata_", ducklake_name, ".main.", tbl_name)
+    paste(metadata_db, "main", tbl_name, sep = ".")
   }
   return(get_ducklake_table(metadata_tbl_name))
 }

--- a/R/time_travel.R
+++ b/R/time_travel.R
@@ -238,7 +238,7 @@ list_table_snapshots <- function(table_name = NULL, ducklake_name = NULL, conn =
 #' @param timestamp Optional timestamp to restore to (POSIXct, converted to
 #'   UTC, or character already in UTC)
 #' @param author Optional author to record on the restore snapshot, for the
-#'   audit trail
+#'   audit trail. Defaults to the `ducklake.author` option when it is set.
 #' @param commit_message Optional commit message for the restore snapshot.
 #'   Defaults to a message noting the restore point (e.g.
 #'   `"Restored my_table to snapshot 5"`).

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -57,7 +57,9 @@ begin_transaction <- function(conn = NULL) {
 #' metadata (author, commit message, and extra info) to the snapshot.
 #'
 #' @param conn Optional DuckDB connection object. If not provided, uses the default ducklake connection.
-#' @param author Optional author name to associate with the snapshot
+#' @param author Author to record on the snapshot. Defaults to the
+#'   `ducklake.author` option when it is set (see `?ducklake`), otherwise
+#'   none.
 #' @param commit_message Optional commit message describing the changes
 #' @param commit_extra_info Optional extra information about the commit
 #'
@@ -72,7 +74,9 @@ begin_transaction <- function(conn = NULL) {
 #' If \code{author}, \code{commit_message}, or \code{commit_extra_info} are provided,
 #' they will be set using \code{CALL ducklake.set_commit_message()} within the
 #' transaction before the \code{COMMIT} statement, as required by the DuckLake
-#' v1.0 specification.
+#' v1.0 specification. An author set once for the session with
+#' `options(ducklake.author = "...")` is recorded on every commit that does
+#' not name one; the `author` argument wins when both are given.
 #'
 #' The commit is confirmed with one message naming the snapshot it created,
 #' with the author and commit message when they were given. The id is the
@@ -111,6 +115,7 @@ commit_transaction <- function(
   if (is.null(conn)) {
     conn <- get_ducklake_connection()
   }
+  author <- resolve_author(author)
 
   # In DuckLake v1.0, commit metadata must be set within the transaction
   # using CALL set_commit_message() before COMMIT
@@ -177,16 +182,22 @@ commit_transaction <- function(
   invisible(TRUE)
 }
 
-#' Set metadata for the most recent snapshot
+#' Set metadata for a snapshot
 #'
-#' Fills in the author, commit message, and/or extra info of the most
-#' recent snapshot in a DuckLake catalog after it was committed, by
-#' updating the `ducklake_snapshot_changes` metadata table directly.
+#' Fills in the author, commit message, and/or extra info of a snapshot in
+#' a DuckLake catalog after it was committed, by updating the
+#' `ducklake_snapshot_changes` metadata table directly. The most recent
+#' snapshot by default; `snapshot_id` names another.
 #'
 #' @param ducklake_name The name of the DuckLake catalog
-#' @param author Optional author name to associate with the snapshot
+#' @param author Optional author name to associate with the snapshot. The
+#'   `ducklake.author` option is not read here: labeling a snapshot after
+#'   the fact is a deliberate edit, so the author is always spelled out.
 #' @param commit_message Optional commit message describing the changes
 #' @param commit_extra_info Optional extra information about the commit
+#' @param snapshot_id Optional snapshot id (see [list_table_snapshots()]).
+#'   `NULL`, the default, means the most recent snapshot. An id the lake
+#'   does not have is an error.
 #' @param conn Optional DuckDB connection object. If not provided, uses the default ducklake connection.
 #' @param overwrite Replace values the snapshot already carries (default
 #'   `FALSE`). By default only empty fields are filled in, and the call
@@ -204,11 +215,20 @@ commit_transaction <- function(
 #' that was committed without them, such as one made interactively or by a
 #' client that could not set them.
 #'
+#' Snapshot 0 is the lake's creation, which DuckLake writes without an
+#' author or a message. [attach_ducklake()] labels it for a lake it
+#' creates; for a lake created before that, or attached read-only, pinned
+#' to a snapshot, or inside a transaction at the time, pass
+#' `snapshot_id = 0` here.
+#'
 #' It writes to the catalog's metadata table outside DuckLake's transaction
 #' and conflict model, and an overwrite leaves no trace of the previous
 #' value. That is why it fills blanks only unless `overwrite = TRUE`. Where
 #' the snapshot history is the audit trail (GxP, 21 CFR Part 11), set
-#' metadata at commit time and leave `overwrite` alone.
+#' metadata at commit time and leave `overwrite` alone. Call it outside a
+#' transaction: a DuckDB transaction can write to one attached database,
+#' and this one writes to the metadata catalog, so a lake write after it
+#' in the same transaction would fail.
 #'
 #' @examplesIf ducklake_extension_available()
 #' lake_dir <- tempfile("meta_lake_")
@@ -230,6 +250,10 @@ commit_transaction <- function(
 #' try(set_snapshot_metadata("meta_lake", commit_message = "Reworded"))
 #' set_snapshot_metadata("meta_lake", commit_message = "Reworded", overwrite = TRUE)
 #'
+#' # The creation snapshot has the message attach_ducklake() gave it and no
+#' # author yet: name one
+#' set_snapshot_metadata("meta_lake", author = "Data Team", snapshot_id = 0)
+#'
 #' detach_ducklake("meta_lake", shutdown = TRUE)
 #' unlink(lake_dir, recursive = TRUE)
 set_snapshot_metadata <- function(
@@ -237,6 +261,7 @@ set_snapshot_metadata <- function(
   author = NULL,
   commit_message = NULL,
   commit_extra_info = NULL,
+  snapshot_id = NULL,
   conn = NULL,
   overwrite = FALSE
 ) {
@@ -256,47 +281,61 @@ set_snapshot_metadata <- function(
     return(invisible(FALSE))
   }
 
-  prefix <- metadata_prefix(ducklake_name, conn)
-  changes_ref <- paste0(prefix, ".ducklake_snapshot_changes")
-  latest <- sprintf(
-    "(SELECT MAX(snapshot_id) FROM %s.ducklake_snapshot)", prefix
-  )
-
-  if (!isTRUE(overwrite)) {
-    current <- tryCatch(
+  if (is.null(snapshot_id)) {
+    snapshot_id <- tryCatch(
       DBI::dbGetQuery(
         conn,
         sprintf(
-          "SELECT author, commit_message, commit_extra_info FROM %s WHERE snapshot_id = %s",
-          changes_ref, latest
+          "SELECT MAX(snapshot_id) AS id FROM %s.ducklake_snapshot",
+          metadata_prefix(ducklake_name, conn)
         )
-      ),
-      error = function(e) NULL
-    )
-    if (!is.null(current) && nrow(current) == 1) {
-      taken <- names(provided)[!is.na(unlist(current[1, names(provided)]))]
-      if (length(taken) > 0) {
-        cli::cli_abort(c(
-          "The latest snapshot already has {.field {taken}} set.",
-          "i" = "Metadata belongs on the commit: record it with {.fn with_transaction} or {.fn commit_transaction}.",
-          "i" = "Pass {.code overwrite = TRUE} to replace {cli::qty(length(taken))}{?it/them}; the previous value{?s} {?is/are} not kept."
-        ))
+      )$id,
+      error = function(e) {
+        cli::cli_warn("Could not read the lake's snapshots: {e$message}")
+        NULL
       }
+    )
+    if (is.null(snapshot_id)) {
+      return(invisible(FALSE))
+    }
+  } else if (
+    !is.numeric(snapshot_id) || length(snapshot_id) != 1 ||
+      is.na(snapshot_id) || snapshot_id < 0 || snapshot_id != trunc(snapshot_id)
+  ) {
+    cli::cli_abort(
+      "{.arg snapshot_id} must be a single non-negative whole number."
+    )
+  }
+  snapshot_id <- as.integer(snapshot_id)
+
+  # One read serves two checks: the snapshot must exist (a bound UPDATE on
+  # a missing id affects no rows and raises nothing), and unless
+  # overwriting, the supplied fields must still be empty
+  current <- tryCatch(
+    read_snapshot_metadata(ducklake_name, snapshot_id, conn),
+    error = function(e) NULL
+  )
+  if (!is.null(current) && nrow(current) == 0) {
+    cli::cli_abort(c(
+      "Snapshot {snapshot_id} does not exist in {.val {ducklake_name}}.",
+      "i" = "{.fn list_table_snapshots} lists the snapshots the lake has."
+    ))
+  }
+  if (!isTRUE(overwrite) && !is.null(current)) {
+    taken <- names(provided)[!is.na(unlist(current[1, names(provided)]))]
+    if (length(taken) > 0) {
+      cli::cli_abort(c(
+        "Snapshot {snapshot_id} already has {.field {taken}} set.",
+        "i" = "Metadata belongs on the commit: record it with {.fn with_transaction} or {.fn commit_transaction}.",
+        "i" = "Pass {.code overwrite = TRUE} to replace {cli::qty(length(taken))}{?it/them}; the previous value{?s} {?is/are} not kept."
+      ))
     }
   }
 
-  # Parameterized SET clause: values never touch the SQL text
-  update_sql <- sprintf(
-    "UPDATE %s SET %s WHERE snapshot_id = %s",
-    changes_ref,
-    paste0(names(provided), " = ?", collapse = ", "),
-    latest
-  )
-
   tryCatch(
     {
-      DBI::dbExecute(conn, update_sql, params = unname(provided))
-      dl_inform("Snapshot metadata updated.")
+      update_snapshot_metadata(ducklake_name, snapshot_id, provided, conn)
+      dl_inform("Updated the metadata of snapshot {snapshot_id}.")
       invisible(TRUE)
     },
     error = function(e) {
@@ -304,6 +343,86 @@ set_snapshot_metadata <- function(
       invisible(FALSE)
     }
   )
+}
+
+#' One snapshot's metadata row: author, commit_message, commit_extra_info
+#'
+#' Zero rows when the snapshot does not exist. Catalog errors propagate, so
+#' the caller decides whether they are a warning or an error.
+#' @noRd
+read_snapshot_metadata <- function(ducklake_name, snapshot_id, conn) {
+  DBI::dbGetQuery(
+    conn,
+    sprintf(
+      "SELECT author, commit_message, commit_extra_info FROM %s.ducklake_snapshot_changes WHERE snapshot_id = ?",
+      metadata_prefix(ducklake_name, conn)
+    ),
+    params = list(as.integer(snapshot_id))
+  )
+}
+
+#' Parameterized UPDATE of one snapshot's metadata fields
+#'
+#' `values` is a named list of any of author, commit_message, and
+#' commit_extra_info; only its names reach the SQL text, the values and the
+#' id are bound parameters. `condition` is extra SQL ANDed into the WHERE
+#' clause.
+#'
+#' @returns The number of rows updated: 1, or 0 when no row matched.
+#' @noRd
+update_snapshot_metadata <- function(ducklake_name, snapshot_id, values, conn,
+                                     condition = NULL) {
+  where <- "snapshot_id = ?"
+  if (!is.null(condition)) {
+    where <- paste(where, "AND", condition)
+  }
+  DBI::dbExecute(
+    conn,
+    sprintf(
+      "UPDATE %s.ducklake_snapshot_changes SET %s WHERE %s",
+      metadata_prefix(ducklake_name, conn),
+      paste0(names(values), " = ?", collapse = ", "),
+      where
+    ),
+    params = c(unname(values), list(as.integer(snapshot_id)))
+  )
+}
+
+#' Label the creation snapshot of a lake this call just created
+#'
+#' DuckLake writes snapshot 0 during ATTACH and ignores set_commit_message()
+#' around it, so the label is one conditional UPDATE: snapshot 0 takes
+#' `author` and `commit_message` only while it is the lake's sole snapshot
+#' and carries no metadata, which is how DuckLake leaves a lake it has just
+#' created. The rows-affected count says whether that was the case, so
+#' there is no probe and no window between probe and write. Silent; a
+#' failure warns.
+#'
+#' @returns Invisibly, `TRUE` when snapshot 0 was labeled.
+#' @noRd
+label_creation_snapshot <- function(ducklake_name, author, commit_message, conn) {
+  values <- list(author = author, commit_message = commit_message)
+  values <- values[!vapply(values, is.null, logical(1))]
+  if (length(values) == 0) {
+    return(invisible(FALSE))
+  }
+  sole_and_blank <- sprintf(
+    "author IS NULL AND commit_message IS NULL AND commit_extra_info IS NULL AND (SELECT COUNT(*) FROM %s.ducklake_snapshot) = 1",
+    metadata_prefix(ducklake_name, conn)
+  )
+  n <- tryCatch(
+    update_snapshot_metadata(
+      ducklake_name, 0L, values, conn, condition = sole_and_blank
+    ),
+    error = function(e) {
+      cli::cli_warn(c(
+        "Could not label the lake's creation snapshot: {e$message}",
+        "i" = "Label it later with {.code set_snapshot_metadata('{ducklake_name}', ..., snapshot_id = 0)}."
+      ))
+      0L
+    }
+  )
+  invisible(n == 1)
 }
 
 #' Execute code within a transaction
@@ -315,7 +434,9 @@ set_snapshot_metadata <- function(
 #'
 #' @param expr An R expression or code block to execute within the transaction.
 #'   Can be a single statement or a \code{\{...\}} block containing multiple statements.
-#' @param author Optional author name to associate with the snapshot
+#' @param author Author to record on the snapshot. Defaults to the
+#'   `ducklake.author` option when it is set (see `?ducklake`), otherwise
+#'   none.
 #' @param commit_message Optional commit message describing the changes
 #' @param commit_extra_info Optional extra information about the commit
 #' @param conn Optional DuckDB connection object. If not provided, uses the default ducklake connection.

--- a/R/utils.R
+++ b/R/utils.R
@@ -293,20 +293,29 @@ split_table_name <- function(table_name) {
 
 #' Quoted prefix of a lake's metadata catalog for SQL text
 #'
-#' DuckDB and SQLite catalogs keep the DuckLake tables in a `main` schema;
-#' PostgreSQL and MySQL catalogs expose them at the top level. Resolves the
-#' backend from the lake's own registry entry, not the current database.
+#' A lake attached with `metadata_schema` keeps its DuckLake tables in that
+#' schema, which the lake's registry entry remembers: the metadata database
+#' is hidden from DuckDB's catalog functions, so the schema cannot be read
+#' back later. Otherwise DuckDB and SQLite catalogs keep the tables in a
+#' `main` schema, and PostgreSQL and MySQL catalogs expose them at the top
+#' level. Resolves the backend from the registry entry, not the current
+#' database.
 #'
 #' @param ducklake_name The lake name.
 #' @param conn A DBI connection used for quoting rules.
-#' @returns A string such as `"__ducklake_metadata_lake".main`.
+#' @returns A string such as `__ducklake_metadata_lake.main`, each part
+#'   quoted when its spelling calls for it.
 #' @noRd
 metadata_prefix <- function(ducklake_name, conn = get_ducklake_connection()) {
-  meta_db <- paste0("__ducklake_metadata_", ducklake_name)
+  meta_db <- quote_ident(paste0("__ducklake_metadata_", ducklake_name), conn)
+  schema <- .ducklake_env$lakes[[ducklake_name]]$metadata_schema
+  if (!is.null(schema)) {
+    return(paste0(meta_db, ".", quote_ident(schema, conn)))
+  }
   if (get_ducklake_backend(ducklake_name) %in% c("postgres", "mysql")) {
-    quote_ident(meta_db, conn)
+    meta_db
   } else {
-    paste0(quote_ident(meta_db, conn), ".main")
+    paste0(meta_db, ".main")
   }
 }
 
@@ -439,4 +448,52 @@ ensure_local_dir <- function(path) {
     dir.create(path, recursive = TRUE, showWarnings = FALSE)
   }
   invisible(path)
+}
+
+#' Validate an optional free-text argument
+#'
+#' `NULL` passes; otherwise the value must be one non-empty string. An
+#' empty string is refused so that an unset environment variable, read
+#' with `Sys.getenv()` into an author or a message, fails here instead of
+#' being recorded as `""`.
+#'
+#' @param x The value to validate.
+#' @param arg Argument name for the error message.
+#' @returns `x`, invisibly.
+#' @noRd
+check_optional_string <- function(x, arg) {
+  if (!is.null(x) &&
+      (!is.character(x) || length(x) != 1 || is.na(x) || !nzchar(x))) {
+    cli::cli_abort("{.arg {arg}} must be `NULL` or a single non-empty string.")
+  }
+  invisible(x)
+}
+
+#' The author for a snapshot this session commits
+#'
+#' An explicit `author` wins; otherwise the `ducklake.author` option, when
+#' set; otherwise `NULL`, which records no author. Used at the package's
+#' commit points (`commit_transaction()`, and through it
+#' `with_transaction()` and `restore_table_version()`) and for the creation
+#' snapshot `attach_ducklake()` labels. Not used by
+#' `set_snapshot_metadata()`: the person labeling a snapshot after the fact
+#' is not always the one who committed it.
+#'
+#' @param author An author name, or `NULL` to fall back to the option.
+#' @returns A single string, or `NULL`.
+#' @noRd
+resolve_author <- function(author = NULL) {
+  check_optional_string(author, "author")
+  if (!is.null(author)) {
+    return(author)
+  }
+  option <- getOption("ducklake.author")
+  if (!is.null(option) &&
+      (!is.character(option) || length(option) != 1 || is.na(option) ||
+         !nzchar(option))) {
+    cli::cli_abort(
+      "The {.code ducklake.author} option must be a single non-empty string, or `NULL`."
+    )
+  }
+  option
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -92,7 +92,7 @@ The medallion pattern organizes a lake in layers: bronze holds data exactly as i
 library(ducklake)
 library(dplyr)
 
-attach_ducklake("my_data_lake", lake_path = tempdir())
+attach_ducklake("my_data_lake", lake_path = tempdir(), author = "Data Engineer")
 ```
 
 One call opens a lake, and creates it first when nothing is at the path yet. By default the catalog is a DuckDB file stored next to the data. A lake that several people write to keeps its catalog in SQLite or PostgreSQL instead, and [Choosing a Deployment](https://tgerke.github.io/ducklake-r/articles/deployment.html) walks through that choice.
@@ -173,7 +173,7 @@ with_transaction(
 
 ### See the history
 
-`list_table_snapshots()` lists every commit in the lake, across all layers. The ids are the ones the confirmations printed, and snapshot 0 is the lake's creation.
+`list_table_snapshots()` lists every commit in the lake, across all layers. The ids are the ones the confirmations printed, and snapshot 0 is the lake's creation, recorded under the author `attach_ducklake()` was given.
 
 ```{r history}
 list_table_snapshots() |>

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ history, detach.
 library(ducklake)
 library(dplyr)
 
-attach_ducklake("my_data_lake", lake_path = tempdir())
+attach_ducklake("my_data_lake", lake_path = tempdir(), author = "Data Engineer")
 ```
 
 One call opens a lake, and creates it first when nothing is at the path
@@ -228,13 +228,14 @@ in place. All of them are versioned in the same way.
 
 `list_table_snapshots()` lists every commit in the lake, across all
 layers. The ids are the ones the confirmations printed, and snapshot 0
-is the lake’s creation.
+is the lake’s creation, recorded under the author `attach_ducklake()`
+was given.
 
 ``` r
 list_table_snapshots() |>
   select(snapshot_id, author, commit_message)
 #>   snapshot_id        author                           commit_message
-#> 1           0          <NA>                                     <NA>
+#> 1           0 Data Engineer                              Create lake
 #> 2           1 Data Engineer                  Create medallion layers
 #> 3           2 Data Engineer         Initial load of raw vehicle data
 #> 4           3 Data Engineer       Clean and standardize vehicle data
@@ -341,7 +342,8 @@ detailed vignettes:
   up on day one
 - [Clinical Trial Data
   Lake](https://tgerke.github.io/ducklake-r/articles/clinical-trial-datalake.html) -
-  SDTM to ADaM with admiral, analysis results in the lake, and column lineage
+  SDTM to ADaM with admiral, analysis results in the lake, and column
+  lineage
 - [Modifying
   Tables](https://tgerke.github.io/ducklake-r/articles/modifying-tables.html) -
   Choosing how to change a table: joins vs. `rows_*`, upserts,

--- a/man/attach_ducklake.Rd
+++ b/man/attach_ducklake.Rd
@@ -18,7 +18,9 @@ attach_ducklake(
   snapshot_time = NULL,
   automatic_migration = FALSE,
   create = TRUE,
-  metadata_schema = NULL
+  metadata_schema = NULL,
+  author = NULL,
+  commit_message = "Create lake"
 )
 }
 \arguments{
@@ -102,15 +104,26 @@ error rather than a new, empty lake.}
 holds this lake's metadata tables (DuckLake's \code{METADATA_SCHEMA},
 default \code{main}). Lets several lakes share one PostgreSQL database,
 each in its own schema.}
+
+\item{author}{Author to record on snapshot 0, the creation snapshot, when
+this call creates the lake. Defaults to the \code{ducklake.author} option
+when it is set (see \code{?ducklake}), otherwise none. Not written for a
+lake that already exists.}
+
+\item{commit_message}{Commit message to record on snapshot 0 when this
+call creates the lake (default \code{"Create lake"}). \code{NULL}, with no
+author, leaves snapshot 0 as DuckLake writes it, without metadata.}
 }
 \value{
 Invisibly, \code{NULL}. Called for its side effect of attaching the
-DuckLake catalog to the package's DuckDB connection.
+DuckLake catalog to the package's DuckDB connection and, for a lake it
+creates, of labeling snapshot 0.
 }
 \description{
 Wrapper for the ducklake \href{https://ducklake.select/docs/stable/duckdb/usage/connecting}{ATTACH} command.
 Creates a new DuckLake if the specified name does not exist, or connects to
-an existing one. The lake can be detached with \code{\link[=detach_ducklake]{detach_ducklake()}}.
+an existing one, and labels the creation snapshot of a lake it creates.
+The lake can be detached with \code{\link[=detach_ducklake]{detach_ducklake()}}.
 }
 \details{
 By default DuckDB is used as the catalog database. Alternative backends
@@ -126,6 +139,20 @@ interactive session duckdb offers to create \verb{~/.duckdb} the first time it
 connects, and with that the download happens once per machine. To fetch
 the extensions ahead of time, for a container image or a machine that is
 offline when the lake is attached, use \code{\link[=install_ducklake]{install_ducklake()}}.
+
+DuckLake writes snapshot 0 itself when it creates a lake, with no author
+and no commit message. When this call creates the lake, it fills those
+two fields on snapshot 0 from \code{author} and \code{commit_message}, the way
+\code{\link[=set_snapshot_metadata]{set_snapshot_metadata()}} labels a snapshot after the fact, so the
+history from \code{\link[=list_table_snapshots]{list_table_snapshots()}} starts with a labeled entry.
+Nothing is written when the lake already exists, when \code{read_only} is
+set, when the attach is pinned with \code{snapshot_version} or
+\code{snapshot_time}, or when the call runs inside an open transaction;
+\code{set_snapshot_metadata(snapshot_id = 0)} labels such a lake later. The
+write is silent, and a failure to write is a warning, not an error. For
+a PostgreSQL or MySQL catalog, whether the lake already existed is read
+from the catalog after the attach (one snapshot, id 0, no metadata), so
+a lake another client created and never wrote to is labeled too.
 
 For credential management with PostgreSQL or MySQL, consider DuckDB's
 built-in secrets manager instead of embedding credentials in the connection
@@ -158,7 +185,7 @@ See \url{https://github.com/duckdb/duckdb/issues/7892}. The \code{aws} and
 # DuckDB catalog (default)
 lake_dir <- tempfile("my_lake_")
 dir.create(lake_dir)
-attach_ducklake("my_lake", lake_path = lake_dir)
+attach_ducklake("my_lake", lake_path = lake_dir, author = "Data Engineer")
 detach_ducklake("my_lake")
 
 # Custom inlining threshold for a streaming workload

--- a/man/commit_transaction.Rd
+++ b/man/commit_transaction.Rd
@@ -14,7 +14,9 @@ commit_transaction(
 \arguments{
 \item{conn}{Optional DuckDB connection object. If not provided, uses the default ducklake connection.}
 
-\item{author}{Optional author name to associate with the snapshot}
+\item{author}{Author to record on the snapshot. Defaults to the
+\code{ducklake.author} option when it is set (see \code{?ducklake}), otherwise
+none.}
 
 \item{commit_message}{Optional commit message describing the changes}
 
@@ -34,7 +36,9 @@ making them permanent in the database.
 If \code{author}, \code{commit_message}, or \code{commit_extra_info} are provided,
 they will be set using \code{CALL ducklake.set_commit_message()} within the
 transaction before the \code{COMMIT} statement, as required by the DuckLake
-v1.0 specification.
+v1.0 specification. An author set once for the session with
+\code{options(ducklake.author = "...")} is recorded on every commit that does
+not name one; the \code{author} argument wins when both are given.
 
 The commit is confirmed with one message naming the snapshot it created,
 with the author and commit message when they were given. The id is the

--- a/man/ducklake-package.Rd
+++ b/man/ducklake-package.Rd
@@ -13,6 +13,14 @@ A 'tidyverse'-friendly interface to 'DuckLake' \url{https://ducklake.select/}, t
 \section{Package options}{
 
 \describe{
+\item{\code{ducklake.author}}{The author recorded on the snapshots this
+session commits when a call does not name one: \code{commit_transaction()},
+\code{with_transaction()}, \code{restore_table_version()}, and the creation
+snapshot \code{attach_ducklake()} labels. An \code{author} argument wins over
+the option. \code{set_snapshot_metadata()} does not read it, because
+labeling a snapshot after the fact is a deliberate edit, and a write
+made outside a transaction (\code{create_table()} on its own) records no
+author either way. Unset by default.}
 \item{\code{ducklake.verbose}}{When \code{FALSE}, the confirmations the package
 emits after each operation ("Committed snapshot 3: ...", "Added column
 ...") are suppressed, which keeps pipeline logs quiet. Warnings,

--- a/man/restore_table_version.Rd
+++ b/man/restore_table_version.Rd
@@ -22,7 +22,7 @@ restore_table_version(
 UTC, or character already in UTC)}
 
 \item{author}{Optional author to record on the restore snapshot, for the
-audit trail}
+audit trail. Defaults to the \code{ducklake.author} option when it is set.}
 
 \item{commit_message}{Optional commit message for the restore snapshot.
 Defaults to a message noting the restore point (e.g.

--- a/man/set_snapshot_metadata.Rd
+++ b/man/set_snapshot_metadata.Rd
@@ -2,13 +2,14 @@
 % Please edit documentation in R/transactions.R
 \name{set_snapshot_metadata}
 \alias{set_snapshot_metadata}
-\title{Set metadata for the most recent snapshot}
+\title{Set metadata for a snapshot}
 \usage{
 set_snapshot_metadata(
   ducklake_name,
   author = NULL,
   commit_message = NULL,
   commit_extra_info = NULL,
+  snapshot_id = NULL,
   conn = NULL,
   overwrite = FALSE
 )
@@ -16,11 +17,17 @@ set_snapshot_metadata(
 \arguments{
 \item{ducklake_name}{The name of the DuckLake catalog}
 
-\item{author}{Optional author name to associate with the snapshot}
+\item{author}{Optional author name to associate with the snapshot. The
+\code{ducklake.author} option is not read here: labeling a snapshot after
+the fact is a deliberate edit, so the author is always spelled out.}
 
 \item{commit_message}{Optional commit message describing the changes}
 
 \item{commit_extra_info}{Optional extra information about the commit}
+
+\item{snapshot_id}{Optional snapshot id (see \code{\link[=list_table_snapshots]{list_table_snapshots()}}).
+\code{NULL}, the default, means the most recent snapshot. An id the lake
+does not have is an error.}
 
 \item{conn}{Optional DuckDB connection object. If not provided, uses the default ducklake connection.}
 
@@ -32,9 +39,10 @@ stops when a supplied field already has a value.}
 Invisibly returns TRUE on success
 }
 \description{
-Fills in the author, commit message, and/or extra info of the most
-recent snapshot in a DuckLake catalog after it was committed, by
-updating the \code{ducklake_snapshot_changes} metadata table directly.
+Fills in the author, commit message, and/or extra info of a snapshot in
+a DuckLake catalog after it was committed, by updating the
+\code{ducklake_snapshot_changes} metadata table directly. The most recent
+snapshot by default; \code{snapshot_id} names another.
 }
 \details{
 Metadata belongs on the commit: pass \code{author}, \code{commit_message}, and
@@ -44,11 +52,20 @@ the transaction itself. This function is the escape hatch for a snapshot
 that was committed without them, such as one made interactively or by a
 client that could not set them.
 
+Snapshot 0 is the lake's creation, which DuckLake writes without an
+author or a message. \code{\link[=attach_ducklake]{attach_ducklake()}} labels it for a lake it
+creates; for a lake created before that, or attached read-only, pinned
+to a snapshot, or inside a transaction at the time, pass
+\code{snapshot_id = 0} here.
+
 It writes to the catalog's metadata table outside DuckLake's transaction
 and conflict model, and an overwrite leaves no trace of the previous
 value. That is why it fills blanks only unless \code{overwrite = TRUE}. Where
 the snapshot history is the audit trail (GxP, 21 CFR Part 11), set
-metadata at commit time and leave \code{overwrite} alone.
+metadata at commit time and leave \code{overwrite} alone. Call it outside a
+transaction: a DuckDB transaction can write to one attached database,
+and this one writes to the metadata catalog, so a lake write after it
+in the same transaction would fail.
 }
 \examples{
 \dontshow{if (ducklake_extension_available()) withAutoprint(\{ # examplesIf}
@@ -70,6 +87,10 @@ set_snapshot_metadata(
 # A second call refuses to replace them unless told to
 try(set_snapshot_metadata("meta_lake", commit_message = "Reworded"))
 set_snapshot_metadata("meta_lake", commit_message = "Reworded", overwrite = TRUE)
+
+# The creation snapshot has the message attach_ducklake() gave it and no
+# author yet: name one
+set_snapshot_metadata("meta_lake", author = "Data Team", snapshot_id = 0)
 
 detach_ducklake("meta_lake", shutdown = TRUE)
 unlink(lake_dir, recursive = TRUE)

--- a/man/with_transaction.Rd
+++ b/man/with_transaction.Rd
@@ -16,7 +16,9 @@ with_transaction(
 \item{expr}{An R expression or code block to execute within the transaction.
 Can be a single statement or a \code{\{...\}} block containing multiple statements.}
 
-\item{author}{Optional author name to associate with the snapshot}
+\item{author}{Author to record on the snapshot. Defaults to the
+\code{ducklake.author} option when it is set (see \code{?ducklake}), otherwise
+none.}
 
 \item{commit_message}{Optional commit message describing the changes}
 

--- a/tests/testthat/helper-setup.R
+++ b/tests/testthat/helper-setup.R
@@ -22,9 +22,10 @@ skip_if_no_ducklake <- function() {
 #' Create a temporary ducklake for testing
 #'
 #' Creates a test ducklake in a temporary directory with proper DuckLake catalog
-#' 
+#'
+#' @param ... Passed to attach_ducklake()
 #' @return List with ducklake_name, temp_dir, lake_path, and conn
-create_temp_ducklake <- function() {
+create_temp_ducklake <- function(...) {
   skip_if_no_ducklake()
 
   temp_dir <- tempfile()
@@ -38,7 +39,7 @@ create_temp_ducklake <- function() {
   )
   
   # Attach the ducklake - this creates the DuckLake catalog
-  attach_ducklake(ducklake_name, lake_path = temp_dir)
+  attach_ducklake(ducklake_name, lake_path = temp_dir, ...)
   
   # Get the connection
   conn <- get_ducklake_connection()

--- a/tests/testthat/test-author-option.R
+++ b/tests/testthat/test-author-option.R
@@ -1,0 +1,94 @@
+# UNIT TESTS: the ducklake.author option
+#
+# A session-wide default author for the snapshots the package labels. An
+# explicit author wins, set_snapshot_metadata() does not read it, and a
+# malformed value is an error.
+
+test_that("commit points record the session author", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+  old <- options(ducklake.author = "Session Author")
+  on.exit(options(old), add = TRUE)
+
+  begin_transaction()
+  create_table(data.frame(id = 1:2), "opt_t")
+  expect_message(
+    commit_transaction(commit_message = "load"),
+    "Committed snapshot [0-9]+ \\(Session Author\\): load"
+  )
+  expect_equal(list_table_snapshots("opt_t")$author, "Session Author")
+
+  # An explicit author wins
+  with_transaction(create_table(data.frame(id = 1), "opt_u"), author = "Named")
+  expect_equal(list_table_snapshots("opt_u")$author, "Named")
+
+  # with_transaction() and restore_table_version() inherit it
+  with_transaction(
+    rows_insert(get_ducklake_table("opt_t"), data.frame(id = 3L), by = "id")
+  )
+  snaps <- list_table_snapshots("opt_t")
+  expect_equal(snaps$author[which.max(snaps$snapshot_id)], "Session Author")
+
+  restore_table_version("opt_t", version = min(snaps$snapshot_id))
+  snaps <- list_table_snapshots("opt_t")
+  expect_equal(snaps$author[which.max(snaps$snapshot_id)], "Session Author")
+})
+
+test_that("attach_ducklake() records the session author on the creation snapshot", {
+  skip_if_not_installed("duckdb")
+
+  old <- options(ducklake.author = "Session Author")
+  on.exit(options(old), add = TRUE)
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+
+  snaps <- list_table_snapshots()
+  expect_equal(snaps$author, "Session Author")
+  expect_equal(snaps$commit_message, "Create lake")
+
+  # The argument wins over the option
+  other <- create_temp_ducklake(author = "Named")
+  on.exit(cleanup_temp_ducklake(other), add = TRUE)
+  expect_equal(list_table_snapshots()$author, "Named")
+})
+
+test_that("set_snapshot_metadata() and autocommit writes do not read the option", {
+  skip_if_not_installed("duckdb")
+  skip_if_not_installed("dplyr")
+
+  lake <- create_temp_ducklake()
+  on.exit(cleanup_temp_ducklake(lake), add = TRUE)
+  old <- options(ducklake.author = "Session Author")
+  on.exit(options(old), add = TRUE)
+
+  # A write outside a transaction records no metadata, option or not
+  create_table(data.frame(id = 1), "opt_meta")
+  expect_true(is.na(list_table_snapshots("opt_meta")$author))
+
+  suppressMessages(
+    set_snapshot_metadata(lake$ducklake_name, commit_message = "labeled later")
+  )
+  snaps <- list_table_snapshots("opt_meta")
+  expect_true(is.na(snaps$author))
+  expect_equal(snaps$commit_message, "labeled later")
+})
+
+test_that("a malformed ducklake.author option is an error", {
+  for (bad in list(1, "", c("a", "b"), NA_character_)) {
+    old <- options(ducklake.author = bad)
+    expect_error(ducklake:::resolve_author(), "ducklake.author")
+    options(old)
+  }
+
+  # An explicit author is validated the same way, and wins over the option
+  expect_error(ducklake:::resolve_author(""), "single non-empty string")
+  old <- options(ducklake.author = "Session Author")
+  on.exit(options(old), add = TRUE)
+  expect_equal(ducklake:::resolve_author("Named"), "Named")
+  expect_equal(ducklake:::resolve_author(), "Session Author")
+  options(ducklake.author = NULL)
+  expect_null(ducklake:::resolve_author())
+})

--- a/tests/testthat/test-creation-snapshot.R
+++ b/tests/testthat/test-creation-snapshot.R
@@ -1,0 +1,300 @@
+# UNIT TESTS: the creation snapshot
+#
+# DuckLake writes snapshot 0 when it creates a lake, with no author or
+# message. attach_ducklake() labels it for a lake it creates, and
+# set_snapshot_metadata(snapshot_id = 0) labels it after the fact.
+
+# A lake attached by hand, so the attach arguments are what is under test
+new_lake_spec <- function() {
+  skip_if_no_ducklake()
+  dir <- tempfile("creation_")
+  dir.create(dir, recursive = TRUE)
+  list(name = paste0("crlake_", sample.int(.Machine$integer.max, 1)), dir = dir)
+}
+
+cleanup_lake_spec <- function(lake) {
+  tryCatch(detach_ducklake(lake$name), error = function(e) NULL)
+  unlink(lake$dir, recursive = TRUE)
+}
+
+creation_row <- function() {
+  snaps <- list_table_snapshots()
+  snaps[snaps$snapshot_id == 0, , drop = FALSE]
+}
+
+test_that("attach_ducklake() labels snapshot 0 of a lake it creates", {
+  skip_if_not_installed("dplyr")
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+
+  expect_no_message(
+    attach_ducklake(lake$name, lake_path = lake$dir),
+    class = "ducklake_message"
+  )
+
+  snaps <- list_table_snapshots()
+  expect_equal(nrow(snaps), 1)
+  expect_equal(snaps$snapshot_id, 0)
+  expect_true(is.na(snaps$author))
+  expect_equal(snaps$commit_message, "Create lake")
+  expect_true(is.na(snaps$commit_extra_info))
+
+  # The raw metadata row agrees
+  row <- get_metadata_table("ducklake_snapshot_changes") |> dplyr::collect()
+  expect_equal(row$snapshot_id, 0)
+  expect_equal(row$commit_message, "Create lake")
+})
+
+test_that("the author is recorded when given, and commit_message = NULL opts out", {
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+
+  attach_ducklake(lake$name, lake_path = lake$dir, author = "Data Engineer")
+  snaps <- list_table_snapshots()
+  expect_equal(snaps$author, "Data Engineer")
+  expect_equal(snaps$commit_message, "Create lake")
+
+  other <- new_lake_spec()
+  on.exit(cleanup_lake_spec(other), add = TRUE)
+  attach_ducklake(other$name, lake_path = other$dir, commit_message = NULL)
+  snaps <- list_table_snapshots()
+  expect_equal(nrow(snaps), 1)
+  expect_true(is.na(snaps$author))
+  expect_true(is.na(snaps$commit_message))
+})
+
+test_that("a lake that already exists is left alone", {
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+
+  # Created without a label, then opened again with one: still blank
+  attach_ducklake(lake$name, lake_path = lake$dir, commit_message = NULL)
+  detach_ducklake(lake$name)
+  attach_ducklake(lake$name, lake_path = lake$dir, author = "Someone")
+  snaps <- list_table_snapshots()
+  expect_true(is.na(snaps$author))
+  expect_true(is.na(snaps$commit_message))
+
+  # create = FALSE opens an existing lake, so it never labels either
+  detach_ducklake(lake$name)
+  attach_ducklake(lake$name, lake_path = lake$dir, create = FALSE, author = "Someone")
+  expect_true(is.na(list_table_snapshots()$commit_message))
+
+  # A labeled lake keeps its first label
+  labeled <- new_lake_spec()
+  on.exit(cleanup_lake_spec(labeled), add = TRUE)
+  attach_ducklake(labeled$name, lake_path = labeled$dir, author = "First")
+  detach_ducklake(labeled$name)
+  attach_ducklake(labeled$name, lake_path = labeled$dir, author = "Second")
+  expect_equal(list_table_snapshots()$author, "First")
+
+  # And so does a second attach while it is still attached
+  attach_ducklake(labeled$name, lake_path = labeled$dir, author = "Third")
+  expect_equal(list_table_snapshots()$author, "First")
+})
+
+test_that("a read-only attach writes nothing and does not warn", {
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+
+  # DuckDB cannot create a lake read-only, so the lake exists blank first
+  attach_ducklake(lake$name, lake_path = lake$dir, commit_message = NULL)
+  detach_ducklake(lake$name)
+  expect_no_warning(
+    attach_ducklake(lake$name, lake_path = lake$dir, read_only = TRUE, author = "x")
+  )
+  snaps <- list_table_snapshots()
+  expect_true(is.na(snaps$author))
+  expect_true(is.na(snaps$commit_message))
+})
+
+test_that("a snapshot-pinned attach of a new lake writes nothing", {
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+
+  # The lake is read-only but its metadata catalog is writable: only the
+  # guard in attach_ducklake() stops the label
+  attach_ducklake(lake$name, lake_path = lake$dir, snapshot_version = 0, author = "x")
+  snaps <- list_table_snapshots()
+  expect_equal(nrow(snaps), 1)
+  expect_true(is.na(snaps$author))
+  expect_true(is.na(snaps$commit_message))
+})
+
+test_that("an attach inside an open transaction skips the label and leaves writes working", {
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+
+  begin_transaction()
+  attach_ducklake(lake$name, lake_path = lake$dir, author = "x")
+  create_table(data.frame(id = 1), "t")
+  expect_message(commit_transaction(), "Committed snapshot 1")
+
+  zero <- creation_row()
+  expect_true(is.na(zero$author))
+  expect_true(is.na(zero$commit_message))
+
+  # Labeled after the fact
+  suppressMessages(set_snapshot_metadata(
+    lake$name, author = "x", commit_message = "Create lake", snapshot_id = 0
+  ))
+  zero <- creation_row()
+  expect_equal(zero$author, "x")
+  expect_equal(zero$commit_message, "Create lake")
+})
+
+test_that("the SQLite backend is labeled and the label persists", {
+  skip_if_no_ducklake()
+
+  dir <- tempfile("creation_sqlite_")
+  dir.create(file.path(dir, "data"), recursive = TRUE)
+  name <- paste0("crsqlite_", sample.int(.Machine$integer.max, 1))
+  on.exit({
+    tryCatch(detach_ducklake(name), error = function(e) NULL)
+    unlink(dir, recursive = TRUE)
+  }, add = TRUE)
+  catalog <- file.path(dir, "metadata.sqlite")
+  attach_sqlite <- function(author) {
+    tryCatch(
+      attach_ducklake(
+        name, lake_path = file.path(dir, "data"), backend = "sqlite",
+        catalog_connection_string = catalog, author = author
+      ),
+      error = function(e) {
+        if (grepl("sqlite", conditionMessage(e), ignore.case = TRUE)) {
+          skip(paste("SQLite backend unavailable:", conditionMessage(e)))
+        }
+        stop(e)
+      }
+    )
+  }
+
+  attach_sqlite("Data Engineer")
+  snaps <- list_table_snapshots()
+  expect_equal(snaps$author, "Data Engineer")
+  expect_equal(snaps$commit_message, "Create lake")
+
+  detach_ducklake(name)
+  attach_sqlite("Someone Else")
+  snaps <- list_table_snapshots()
+  expect_equal(snaps$author, "Data Engineer")
+  expect_equal(snaps$commit_message, "Create lake")
+})
+
+test_that("metadata_schema is honored end to end", {
+  skip_if_not_installed("dplyr")
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+
+  attach_ducklake(
+    lake$name, lake_path = lake$dir, metadata_schema = "meta", author = "Data Engineer"
+  )
+  expect_equal(get_ducklake_env()$lakes[[lake$name]]$metadata_schema, "meta")
+  expect_match(ducklake:::metadata_prefix(lake$name), '[.]"?meta"?$')
+
+  snaps <- list_table_snapshots()
+  expect_equal(snaps$author, "Data Engineer")
+  expect_equal(snaps$commit_message, "Create lake")
+
+  # The other metadata writers and readers find the schema too
+  expect_no_warning(
+    suppressMessages(set_snapshot_metadata(lake$name, commit_extra_info = "x"))
+  )
+  expect_equal(list_table_snapshots()$commit_extra_info, "x")
+  row <- get_metadata_table("ducklake_snapshot_changes") |> dplyr::collect()
+  expect_equal(row$commit_extra_info, "x")
+  create_table(data.frame(id = 1:2), "t")
+  expect_no_warning(get_table_partitions("t"))
+
+  # A second attach without the argument keeps the registered schema
+  attach_ducklake(lake$name, lake_path = lake$dir)
+  expect_equal(get_ducklake_env()$lakes[[lake$name]]$metadata_schema, "meta")
+})
+
+test_that("the label stays out of a table's history", {
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+
+  attach_ducklake(lake$name, lake_path = lake$dir)
+  create_table(data.frame(id = 1:2), "t")
+  expect_false(0 %in% list_table_snapshots("t")$snapshot_id)
+  expect_true(0 %in% list_table_snapshots()$snapshot_id)
+})
+
+test_that("author and commit_message are validated before anything is created", {
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+
+  expect_error(
+    attach_ducklake(lake$name, lake_path = lake$dir, author = c("a", "b")),
+    "single non-empty string"
+  )
+  expect_error(
+    attach_ducklake(lake$name, lake_path = lake$dir, author = ""),
+    "single non-empty string"
+  )
+  expect_error(
+    attach_ducklake(lake$name, lake_path = lake$dir, commit_message = 1),
+    "single non-empty string"
+  )
+  expect_false(file.exists(file.path(lake$dir, paste0(lake$name, ".ducklake"))))
+})
+
+test_that("set_snapshot_metadata() on a fresh lake targets snapshot 0", {
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+  attach_ducklake(lake$name, lake_path = lake$dir)
+
+  expect_message(set_snapshot_metadata(lake$name, author = "Late Author"), "snapshot 0")
+  expect_equal(list_table_snapshots()$author, "Late Author")
+  expect_error(set_snapshot_metadata(lake$name, commit_message = "x"), "already has")
+  suppressMessages(
+    set_snapshot_metadata(lake$name, commit_message = "Create the lake", overwrite = TRUE)
+  )
+  expect_equal(list_table_snapshots()$commit_message, "Create the lake")
+})
+
+test_that("snapshot_id picks the snapshot to label", {
+  lake <- new_lake_spec()
+  on.exit(cleanup_lake_spec(lake), add = TRUE)
+  attach_ducklake(lake$name, lake_path = lake$dir)
+  create_table(data.frame(id = 1), "one")
+  create_table(data.frame(id = 2), "two")
+
+  expect_message(
+    set_snapshot_metadata(
+      lake$name, author = "A", commit_message = "first table", snapshot_id = 1
+    ),
+    "snapshot 1"
+  )
+  snaps <- list_table_snapshots()
+  expect_equal(snaps$author[snaps$snapshot_id == 1], "A")
+  expect_true(is.na(snaps$author[snaps$snapshot_id == 2]))
+  expect_equal(snaps$commit_message[snaps$snapshot_id == 0], "Create lake")
+
+  expect_error(
+    set_snapshot_metadata(lake$name, commit_message = "x", snapshot_id = 0),
+    "already has"
+  )
+  expect_error(
+    set_snapshot_metadata(lake$name, author = "x", snapshot_id = 99),
+    "does not exist"
+  )
+  expect_error(
+    set_snapshot_metadata(lake$name, author = "x", snapshot_id = "a"),
+    "whole number"
+  )
+  expect_error(
+    set_snapshot_metadata(lake$name, author = "x", snapshot_id = -1),
+    "whole number"
+  )
+  expect_error(
+    set_snapshot_metadata(lake$name, author = "x", snapshot_id = 1.5),
+    "whole number"
+  )
+
+  # The default is still the latest snapshot
+  suppressMessages(set_snapshot_metadata(lake$name, author = "B"))
+  snaps <- list_table_snapshots()
+  expect_equal(snaps$author[snaps$snapshot_id == 2], "B")
+})

--- a/tests/testthat/test-maintenance.R
+++ b/tests/testthat/test-maintenance.R
@@ -87,6 +87,7 @@ test_that("expire_snapshots expires specific versions", {
 
   expired <- expire_snapshots(versions = oldest)
   expect_equal(expired$snapshot_id, oldest)
+  expect_equal(expired$commit_message, "Create lake")
   expect_false(oldest %in% list_table_snapshots()$snapshot_id)
 })
 

--- a/tests/testthat/test-multi-backend.R
+++ b/tests/testthat/test-multi-backend.R
@@ -238,6 +238,32 @@ test_that("build_attach_sql renders CREATE_IF_NOT_EXISTS and METADATA_SCHEMA", {
   expect_false(grepl("CREATE_IF_NOT_EXISTS|METADATA_SCHEMA", sql3))
 })
 
+test_that("metadata_prefix() follows the registry's backend and metadata schema", {
+  skip_if_not_installed("duckdb")
+
+  conn <- get_ducklake_connection()
+  on.exit(ducklake:::unregister_lake("pfx_pg"), add = TRUE)
+  on.exit(ducklake:::unregister_lake("pfx_duck"), add = TRUE)
+
+  # Built with the same quoting helper: duckdb leaves simple names bare
+  q <- function(x) ducklake:::quote_ident(x, conn)
+
+  ducklake:::register_lake("pfx_pg", "postgres", "dbname=x", "study_a")
+  expect_equal(
+    ducklake:::metadata_prefix("pfx_pg", conn),
+    paste0(q("__ducklake_metadata_pfx_pg"), ".", q("study_a"))
+  )
+
+  ducklake:::register_lake("pfx_pg", "postgres", "dbname=x")
+  expect_equal(ducklake:::metadata_prefix("pfx_pg", conn), q("__ducklake_metadata_pfx_pg"))
+
+  ducklake:::register_lake("pfx_duck", "duckdb")
+  expect_equal(
+    ducklake:::metadata_prefix("pfx_duck", conn),
+    paste0(q("__ducklake_metadata_pfx_duck"), ".main")
+  )
+})
+
 test_that("attach_ducklake() creates a missing local lake directory", {
   skip_if_no_ducklake()
 

--- a/vignettes/articles/clinical-trial-datalake.Rmd
+++ b/vignettes/articles/clinical-trial-datalake.Rmd
@@ -64,7 +64,7 @@ project directory or a shared location, and
 team.
 
 ```{r attach, message = FALSE}
-attach_ducklake("clinical_trial_lake", lake_path = article_dir)
+attach_ducklake("clinical_trial_lake", lake_path = article_dir, author = "Data Manager")
 ```
 
 The lake follows the medallion pattern, one schema per layer, so a table's
@@ -671,7 +671,8 @@ runs these programs stays with the sponsor.
 ## The history
 
 `list_table_snapshots()` lists every commit in the lake, across all four
-layers, with the author and message each one was given:
+layers, with the author and message each one was given, from the lake's
+creation on:
 
 ```{r history}
 list_table_snapshots() |>

--- a/vignettes/deployment.Rmd
+++ b/vignettes/deployment.Rmd
@@ -183,8 +183,8 @@ and they persist in the catalog for every client.
 #    set DUCKDB_R_HOME=~/.duckdb in ~/.Renviron or the job's environment.
 #    A container image runs install_ducklake() at build time instead.
 
-# 2. Create the lake, and its schemas, in one snapshot
-attach_ducklake("trial", lake_path = "~/lakes/trial")
+# 2. Create the lake, then its schemas
+attach_ducklake("trial", lake_path = "~/lakes/trial", author = "Data Engineer")
 with_transaction({
   create_schema("bronze")
   create_schema("silver")

--- a/vignettes/ducklake.Rmd
+++ b/vignettes/ducklake.Rmd
@@ -61,7 +61,7 @@ One call opens a lake, and creates it first when nothing is at the path
 yet:
 
 ```{r attach, message=FALSE}
-attach_ducklake("my_lake", lake_path = vignette_temp_dir)
+attach_ducklake("my_lake", lake_path = vignette_temp_dir, author = "Data Engineer")
 ```
 
 The same call with the same path opens the lake again in a later session.
@@ -207,8 +207,9 @@ list_table_snapshots("cars")
 
 Each row is one commit. `changes` summarizes what the commit did,
 `author`, `commit_message`, and `commit_extra_info` are the fields passed
-to `with_transaction()`, and `snapshot_id` is the number from the
-confirmation. Any earlier version can be read as a lazy table:
+to `with_transaction()`, or to `attach_ducklake()` for snapshot 0, the
+lake's creation, and `snapshot_id` is the number from the confirmation.
+Any earlier version can be read as a lazy table:
 
 ```{r version}
 # The cars table before the kpl column existed

--- a/vignettes/transactions.Rmd
+++ b/vignettes/transactions.Rmd
@@ -251,7 +251,9 @@ get_ducklake_table("cars") |>
   head()
 ```
 
-**After the fact**: `set_snapshot_metadata()` fills in the metadata of a snapshot that was committed without any, such as a quick interactive change. It updates the `ducklake_snapshot_changes` metadata table directly, outside DuckLake's transaction model, so by default it only fills empty fields and refuses to replace a value that is already there:
+**Once per session**: a session that commits as one person can name the author once, with `options(ducklake.author = "Performance Team")`. Every `commit_transaction()`, `with_transaction()`, and `restore_table_version()` call in the session then records that author unless the call names another. The creation snapshot gets it too, when `attach_ducklake()` creates a lake. `set_snapshot_metadata()` does not read the option: the person labeling a snapshot after the fact is not always the one who committed it.
+
+**After the fact**: `set_snapshot_metadata()` fills in the metadata of a snapshot that was committed without any, such as a quick interactive change. The latest snapshot is the target unless `snapshot_id` names another, such as snapshot 0 of a lake created before ducklake labeled it at attach time. It updates the `ducklake_snapshot_changes` metadata table directly, outside DuckLake's transaction model, so by default it only fills empty fields and refuses to replace a value that is already there:
 
 ```{r metadata-after-fact}
 # A quick interactive change, committed without metadata
@@ -314,7 +316,7 @@ set_ducklake_retry(max_retries = 20, wait_ms = 250, backoff = 2)
 ## Best Practices
 
 1. **Default to `with_transaction()`**: Use it for all standard workflows
-2. **Always add metadata**: Include `author` and `commit_message` for audit trails
+2. **Always add metadata**: Include `author` and `commit_message` for audit trails; `options(ducklake.author = ...)` names the author once for a whole session
 3. **Keep transactions focused**: Group related changes, but avoid overly long transactions; when other sessions write to the same lake, a long-open transaction is the one most likely to conflict
 4. **Handle errors gracefully**: When using manual transactions, always use `tryCatch()` to ensure rollback
 5. **Test rollback behavior**: Verify that your error handling works correctly
@@ -325,7 +327,7 @@ set_ducklake_retry(max_retries = 20, wait_ms = 250, backoff = 2)
 - **`begin_transaction()`**: Start a manual transaction
 - **`commit_transaction(author, commit_message, commit_extra_info)`**: Apply changes from a manual transaction, with optional metadata set at commit time via the DuckLake v1.0 API
 - **`rollback_transaction()`**: Discard changes from a manual transaction
-- **`set_snapshot_metadata()`**: Fill in metadata the most recent snapshot was committed without (`overwrite = TRUE` to replace a value)
+- **`set_snapshot_metadata()`**: Fill in metadata a snapshot was committed without, the most recent one unless `snapshot_id` says otherwise (`overwrite = TRUE` to replace a value)
 
 Transactions ensure data integrity and provide complete audit trails for all changes in your DuckLake.
 

--- a/vignettes/visualizing-your-lake.Rmd
+++ b/vignettes/visualizing-your-lake.Rmd
@@ -53,7 +53,8 @@ authors and commit messages along the way.
 ```{r create-datalake}
 attach_ducklake(
   ducklake_name = "lake_viz_demo",
-  lake_path = vignette_temp_dir
+  lake_path = vignette_temp_dir,
+  author = "Data Engineer"
 )
 
 fleet <- tibble(


### PR DESCRIPTION
Every lake's history opened with an `<NA>` row: DuckLake writes snapshot 0 when it creates a lake and leaves the author and commit message empty, and it ignores `set_commit_message()` around `ATTACH` (confirmed on DuckDB 1.5.5), so the only route is the metadata update `set_snapshot_metadata()` already uses. `attach_ducklake()` gains `author` and `commit_message` (default `"Create lake"`) and writes them onto snapshot 0 with one conditional `UPDATE` right after creating a lake; the statement doubles as the "was this lake new" test. Nothing is written for an existing lake, a read-only or snapshot-pinned attach, `create = FALSE`, or inside an open transaction, where a write to the metadata catalog would block the lake writes that follow.

Also in this PR: a `ducklake.author` option supplies the author for `commit_transaction()`, `with_transaction()`, `restore_table_version()`, and the creation snapshot when a call does not name one (an `author` argument wins, and `set_snapshot_metadata()` does not read it); `set_snapshot_metadata()` gains `snapshot_id`, so an existing lake can label snapshot 0 after the fact; and the lake registry keeps `metadata_schema`, which fixes every metadata reader on a lake attached with `METADATA_SCHEMA` (they all looked in `main`). README re-rendered; Getting Started and the clinical article pass an author to `attach_ducklake()`.

955 tests pass and `R CMD check` is clean locally. The PostgreSQL and MySQL paths are untested locally; there the conditional `UPDATE` is the only "new lake" test, as the roxygen says.
