### PR TITLE
Name the transaction's own snapshot in commit confirmations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,18 +95,27 @@
   DATABASE lake TO iceberg_catalog` and `iceberg_to_ducklake()` live in
   DuckDB's iceberg extension; `vignette("loading-data")` shows them. This closes the
   "one-command Iceberg catalog export" watch item above.
-- **A commit is confirmed with one line naming its snapshot** (2026-09-06).
-  `begin_transaction()` is silent and stashes the lake's current snapshot
-  id; `commit_transaction()` reads it again after `COMMIT` and prints
-  `Committed snapshot N (author): message`, or says nothing changed when
-  the id did not move. DuckLake assigns the id only at commit, and an
-  empty or read-only transaction creates no snapshot (confirmed on the
-  DuckDB and SQLite catalogs). Limitation: DuckLake has no query for "the
-  snapshot this transaction created", so the id is whatever
-  `current_snapshot()` returns right after the commit; with concurrent
-  writers it can belong to a neighbor's commit that landed in between.
-  Functions that commit for themselves (`restore_table_version()`) print
-  no second confirmation.
+- **A commit is confirmed with one line naming its snapshot** (2026-09-06,
+  revised 2026-09-11). `begin_transaction()` is silent and stashes what
+  this connection last committed; `commit_transaction()` reads it again
+  after `COMMIT` and prints `Committed snapshot N (author): message`, or
+  says nothing changed when the id did not move, naming the snapshot the
+  lake stands at. The id comes from DuckLake's
+  `last_committed_snapshot()`, which is connection state: NA until the
+  connection commits a change to the lake, then the id of its latest
+  writing commit, unmoved by empty commits, rollbacks, and other
+  connections' commits (confirmed on DuckDB 1.5.5, extension d8a1881e,
+  with the DuckDB and SQLite catalogs). An extension without the function
+  falls back to `current_snapshot()`, the lake's newest snapshot, which
+  under concurrent writers can be a neighbor's; the 2026-09-06 note that
+  no better query existed was wrong. `begin_transaction()` reads the
+  stash before `BEGIN`: DuckDB starts the transaction on a catalog at the
+  first statement that touches it, and on a SQLite catalog that
+  transaction holds the file's shared lock until it ends, so a neighbor's
+  commit fails with "database is locked" from that point on. The test in
+  `test-transactions.R` stages the neighbor's commits in the window before
+  the first lake statement. Functions that commit for themselves
+  (`restore_table_version()`) print no second confirmation.
 - **Article layout** (2026-09-06): `vignette("ducklake")` (Getting
   Started) is one short linear session; recipes live in topical articles
   (Loading Data; Views, Comments, and Labels; Modifying Tables; Choosing a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # ducklake (development version)
 
+* `commit_transaction()` and `with_transaction()` name the snapshot this
+  connection committed, read from DuckLake's `last_committed_snapshot()`,
+  instead of the lake's newest snapshot right after the commit. The two
+  agree on a lake with one writer, but with several sessions writing at
+  once the newest snapshot could be a neighbor's, and a transaction that
+  changed nothing could be reported as the commit of a snapshot that was
+  not its own. The "no changes" confirmation still names the snapshot the
+  lake stands at. An extension without the function falls back to the
+  previous reading.
+
 * `attach_ducklake()` labels the creation snapshot of a lake it creates.
   DuckLake writes snapshot 0 itself when it makes a lake, with no author
   and no commit message, so every history began with an `<NA>` row. The

--- a/R/transactions.R
+++ b/R/transactions.R
@@ -44,10 +44,15 @@ begin_transaction <- function(conn = NULL) {
     conn <- get_ducklake_connection()
   }
 
+  # Remember what this connection had committed so far, so the commit can
+  # tell a transaction that created a snapshot from one that changed
+  # nothing. Read before BEGIN: DuckDB starts the transaction on the lake's
+  # catalog at the first statement that touches it, and on a SQLite
+  # catalog that holds the file's shared lock until the transaction ends,
+  # so the transaction should not touch the lake before the caller does.
+  before <- committed_snapshot_id(conn)
   DBI::dbExecute(conn, "BEGIN TRANSACTION;")
-  # Remember where the lake stood, so the commit can report whether it
-  # moved and to which snapshot
-  .ducklake_env$txn_snapshot_before <- current_snapshot_id(conn)
+  .ducklake_env$txn_committed_before <- before
   invisible(TRUE)
 }
 
@@ -79,11 +84,12 @@ begin_transaction <- function(conn = NULL) {
 #' not name one; the `author` argument wins when both are given.
 #'
 #' The commit is confirmed with one message naming the snapshot it created,
-#' with the author and commit message when they were given. The id is the
-#' newest snapshot in the lake right after the commit, so when several
-#' sessions write to the same lake it can belong to a commit that landed
-#' just after this one. A transaction that changed nothing creates no
-#' snapshot, and the message says so. `options(ducklake.verbose = FALSE)`
+#' with the author and commit message when they were given. The id comes
+#' from DuckLake's `last_committed_snapshot()`, which tracks this
+#' connection's own commits, so it is right even when other sessions
+#' commit to the same lake at the same time. A transaction that changed
+#' nothing creates no snapshot, and the message says so, naming the
+#' snapshot the lake stands at. `options(ducklake.verbose = FALSE)`
 #' silences these confirmations.
 #'
 #' @examplesIf ducklake_extension_available()
@@ -174,10 +180,18 @@ commit_transaction <- function(
   # Report the snapshot this commit made. The template names locals of
   # this frame, so user text is substituted as a value, never parsed as
   # cli markup.
-  before <- .ducklake_env$txn_snapshot_before
-  .ducklake_env$txn_snapshot_before <- NULL
-  snapshot <- current_snapshot_id(conn)
-  dl_inform(commit_confirmation(snapshot, before, author, commit_message))
+  before <- .ducklake_env$txn_committed_before
+  .ducklake_env$txn_committed_before <- NULL
+  snapshot <- committed_snapshot_id(conn)
+  if (is.na(snapshot) || isTRUE(snapshot == before)) {
+    # This transaction committed nothing: say where the lake stands, which
+    # can be a neighbor's newer snapshot
+    snapshot <- NA_integer_
+    current <- current_snapshot_id(conn)
+  } else {
+    current <- snapshot
+  }
+  dl_inform(commit_confirmation(snapshot, current, author, commit_message))
 
   invisible(TRUE)
 }
@@ -571,7 +585,7 @@ rollback_transaction <- function(conn = NULL) {
   }
 
   DBI::dbExecute(conn, "ROLLBACK;")
-  .ducklake_env$txn_snapshot_before <- NULL
+  .ducklake_env$txn_committed_before <- NULL
   dl_inform("Transaction rolled back.")
   invisible(TRUE)
 }
@@ -595,18 +609,48 @@ current_snapshot_id <- function(conn) {
   )
 }
 
+#' The snapshot this connection last committed, or NA
+#'
+#' DuckLake's `last_committed_snapshot()` is connection state: NA until the
+#' connection commits a change to the lake, then the id of the snapshot its
+#' latest writing commit created, unmoved by empty commits, rollbacks, and
+#' other connections' commits. That makes it the id a commit confirmation
+#' should name. An extension without the function falls back to the lake's
+#' current snapshot, the newest commit from any connection.
+#' @noRd
+committed_snapshot_id <- function(conn) {
+  name <- tryCatch(infer_ducklake_name(NULL, conn), error = function(e) NULL)
+  if (is.null(name)) {
+    return(NA_integer_)
+  }
+  id <- tryCatch(
+    DBI::dbGetQuery(
+      conn,
+      sprintf("FROM %s.last_committed_snapshot()", quote_ident(name, conn))
+    )[[1]],
+    error = function(e) {
+      missing_function <- grepl(
+        "last_committed_snapshot does not exist", conditionMessage(e), fixed = TRUE
+      )
+      if (missing_function) current_snapshot_id(conn) else NA_integer_
+    }
+  )
+  if (length(id) != 1) NA_integer_ else as.integer(id)
+}
+
 #' The cli template for a commit confirmation
 #'
-#' Returns a template that refers to `snapshot`, `author`, and
+#' Returns a template that refers to `snapshot`, `current`, `author`, and
 #' `commit_message` in the caller's frame, where `dl_inform()` interpolates
-#' them.
+#' them. `snapshot` is the id the transaction committed, or NA when it
+#' committed nothing; `current` is then where the lake stands.
 #' @noRd
-commit_confirmation <- function(snapshot, before, author, commit_message) {
+commit_confirmation <- function(snapshot, current, author, commit_message) {
   if (is.na(snapshot)) {
-    return("Transaction committed.")
-  }
-  if (isTRUE(snapshot == before)) {
-    return("Committed with no changes: the lake stays at snapshot {snapshot}.")
+    if (is.na(current)) {
+      return("Transaction committed.")
+    }
+    return("Committed with no changes: the lake stays at snapshot {current}.")
   }
   paste0(
     "Committed snapshot {snapshot}",

--- a/man/commit_transaction.Rd
+++ b/man/commit_transaction.Rd
@@ -41,11 +41,12 @@ v1.0 specification. An author set once for the session with
 not name one; the \code{author} argument wins when both are given.
 
 The commit is confirmed with one message naming the snapshot it created,
-with the author and commit message when they were given. The id is the
-newest snapshot in the lake right after the commit, so when several
-sessions write to the same lake it can belong to a commit that landed
-just after this one. A transaction that changed nothing creates no
-snapshot, and the message says so. \code{options(ducklake.verbose = FALSE)}
+with the author and commit message when they were given. The id comes
+from DuckLake's \code{last_committed_snapshot()}, which tracks this
+connection's own commits, so it is right even when other sessions
+commit to the same lake at the same time. A transaction that changed
+nothing creates no snapshot, and the message says so, naming the
+snapshot the lake stands at. \code{options(ducklake.verbose = FALSE)}
 silences these confirmations.
 }
 \examples{

--- a/tests/testthat/test-transactions.R
+++ b/tests/testthat/test-transactions.R
@@ -79,9 +79,70 @@ test_that("rollback clears the pending confirmation", {
 
   create_table(data.frame(id = 1:2), "rb_t")
   begin_transaction()
-  expect_false(is.null(get_ducklake_env()$txn_snapshot_before))
+  expect_false(is.null(get_ducklake_env()$txn_committed_before))
   rows_insert(get_ducklake_table("rb_t"), data.frame(id = 3L), by = "id")
   expect_message(rollback_transaction(), "rolled back")
-  expect_null(get_ducklake_env()$txn_snapshot_before)
+  expect_null(get_ducklake_env()$txn_committed_before)
   expect_equal(nrow(dplyr::collect(get_ducklake_table("rb_t"))), 2)
+})
+
+test_that("the confirmation names this connection's commit, not a neighbor's", {
+  skip_if_no_ducklake()
+  skip_if_not_installed("dplyr")
+
+  # Two DuckDB connections on one SQLite catalog: the package connection
+  # and a raw neighbor
+  dir <- gsub("/+", "/", tempfile("neighbor_"))
+  dir.create(file.path(dir, "data"), recursive = TRUE)
+  catalog <- file.path(dir, "metadata.sqlite")
+  name <- paste0("nblake_", sample.int(.Machine$integer.max, 1))
+  on.exit({
+    tryCatch(detach_ducklake(name), error = function(e) NULL)
+    unlink(dir, recursive = TRUE)
+  }, add = TRUE)
+  tryCatch(
+    attach_ducklake(
+      name, lake_path = file.path(dir, "data"), backend = "sqlite",
+      catalog_connection_string = catalog
+    ),
+    error = function(e) {
+      if (grepl("sqlite", conditionMessage(e), ignore.case = TRUE)) {
+        skip(paste("SQLite backend unavailable:", conditionMessage(e)))
+      }
+      stop(e)
+    }
+  )
+  create_table(data.frame(id = 1), "mine")
+
+  neighbor <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(neighbor, shutdown = TRUE), add = TRUE, after = FALSE)
+  DBI::dbExecute(neighbor, "LOAD ducklake")
+  DBI::dbExecute(neighbor, "LOAD sqlite")
+  DBI::dbExecute(neighbor, sprintf(
+    "ATTACH 'ducklake:sqlite:%s' AS other (DATA_PATH '%s')",
+    catalog, get_ducklake_info(name)$data_path
+  ))
+
+  # The neighbor commits after begin_transaction() and before this
+  # transaction touches the lake (a SQLite catalog is locked from then
+  # on): the confirmation names this connection's snapshot, not the
+  # neighbor's
+  begin_transaction()
+  DBI::dbExecute(neighbor, "CREATE TABLE other.theirs AS SELECT 1 AS id")
+  create_table(data.frame(id = 2), "mine2")
+  msgs <- capture_ducklake_messages(
+    commit_transaction(author = "Me", commit_message = "mine2")
+  )
+  expect_match(msgs, "Committed snapshot [0-9]+ \\(Me\\): mine2")
+  reported <- as.integer(sub(".*Committed snapshot ([0-9]+).*", "\\1", msgs))
+  expect_equal(reported, list_table_snapshots("mine2")$snapshot_id)
+  expect_false(reported %in% list_table_snapshots("theirs")$snapshot_id)
+
+  # A transaction that changed nothing is not credited with the neighbor's
+  # commit; the lake position it names is the neighbor's snapshot
+  begin_transaction()
+  DBI::dbExecute(neighbor, "INSERT INTO other.theirs VALUES (2)")
+  msgs <- capture_ducklake_messages(commit_transaction())
+  expect_match(msgs, "no changes")
+  expect_match(msgs, paste0("snapshot ", max(list_table_snapshots()$snapshot_id), "\\."))
 })


### PR DESCRIPTION
Follow-up to #64. `commit_transaction()` read `current_snapshot()` right after `COMMIT` and compared it with the value `begin_transaction()` had stashed, so the confirmation named the lake's newest snapshot, which under concurrent writers can be a neighbor's, and a transaction that changed nothing could be credited with a neighbor's commit. The CLAUDE.md note recorded that as unavoidable; it was wrong. DuckLake's `last_committed_snapshot()` is connection state (NA until the connection commits a change, then the id of its latest writing commit, unmoved by empty commits, rollbacks, and other connections' commits; confirmed on DuckDB 1.5.5 with the DuckDB and SQLite catalogs), so both sides of the comparison now read it. The "no changes" line still names the snapshot the lake stands at, and an extension without the function falls back to `current_snapshot()`.

`begin_transaction()` takes its stash before `BEGIN`: DuckDB starts the transaction on a catalog at the first statement that touches it, and on a SQLite catalog that transaction holds the file's shared lock until it ends (a neighbor's commit then fails with "database is locked"), so the transaction should not touch the lake before the caller does. The new test uses that window: a second DuckDB connection commits to the same SQLite catalog between `begin_transaction()` and the first lake statement, once with a real change on our side and once with none, and the confirmation names this connection's snapshot both times. 955 tests pass and `R CMD check` is clean locally.
