### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ducklake
 Title: Interact with 'DuckLake' from R
-Version: 0.7.0.9000
+Version: 0.8.0
 Authors@R: c(
     person("Travis", "Gerke", , "travisgerke@gmail.com", role = c("aut", "cre")),
     person("Stefan", "Linner", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ducklake (development version)
+# ducklake 0.8.0
 
 * `commit_transaction()` and `with_transaction()` name the snapshot this
   connection committed, read from DuckLake's `last_committed_snapshot()`,


### PR DESCRIPTION
Closes out the development version after #64 and #65: DESCRIPTION goes to 0.8.0 and the NEWS heading names the release. No code changes. The merge commit gets the `v0.8.0` tag and the GitHub release, as for 0.7.0.
