### PR TITLE
Start the 0.8.0.9000 development version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ducklake
 Title: Interact with 'DuckLake' from R
-Version: 0.8.0
+Version: 0.8.0.9000
 Authors@R: c(
     person("Travis", "Gerke", , "travisgerke@gmail.com", role = c("aut", "cre")),
     person("Stefan", "Linner", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ducklake (development version)
+
 # ducklake 0.8.0
 
 * `commit_transaction()` and `with_transaction()` name the snapshot this


### PR DESCRIPTION
Follows the 0.8.0 release (#66, tag `v0.8.0`): DESCRIPTION goes to 0.8.0.9000 and NEWS gets a fresh development heading. No code changes.